### PR TITLE
add block download concurrency and fix logger

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,13 +37,13 @@ func main() {
 	memratio := app.Flag("memlimit.ratio", "gomemlimit ratio").Default("0.9").Float()
 	logLevel := app.Flag("logger.level", "log level").Default("INFO").Enum("DEBUG", "INFO", "WARN", "ERROR")
 
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: logLevelMap[*logLevel],
-	}))
-
 	tsdbConvert, tsdbConvertF := registerConvertApp(app)
 	serve, serveF := registerServeApp(app)
 	parsed := kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevelMap[*logLevel],
+	}))
 
 	memlimit.SetGoMemLimitWithOpts(
 		memlimit.WithRatio(*memratio),


### PR DESCRIPTION
## Description

Adding a flag `--convert.download.block-concurrency` to concurrently download tsdb blocks. Also noticed that the log level flag was not being propagated correctly due to parsing the flags after the logger is set.

We have been running the parquet conversion process for our largest tenants and have seen this process take 8+ hours just to download all of the overlapping blocks for a single day. For example, it might need to download 60+ blocks that are anywhere from ~50Gib-100Gib in size. While we can currently download files per block concurrently, since we have so many overlapping blocks it still takes a long time to download since each individual block is downloaded sequentially. By adding concurrent block downloads, we see the download process improve drastically.

## Testing
From our testing, when adding `convert.download.block-concurrency=4`, we saw the block download time decrease from 8 hours to just under 2 hours.

```
{"time":"2025-10-23T17:32:14.302857488Z","level":"INFO","msg":"all blocks downloaded","count":62,"total_duration":6894051669487}
```

Here is a snippet of logging, where we can see each block being downloaded concurrently:

```
{"time":"2025-10-23T20:18:19.511368956Z","level":"INFO","msg":"Converting dates","dates":["2025-09-11T00:00:00Z","2025-09-12T00:00:00Z","2025-09-13T00:00:00Z","2025-09-14T00:00:00Z","2025-09-15T00:00:00Z","2025-09-16T00:00:00Z","2025-09-17T00:00:00Z","2025-09-18T00:00:00Z","2025-09-19T00:00:00Z","2025-09-20T00:00:00Z","2025-09-21T00:00:00Z","2025-09-22T00:00:00Z","2025-09-23T00:00:00Z","2025-09-24T00:00:00Z"]}
{"time":"2025-10-23T20:18:19.511463552Z","level":"INFO","msg":"Opening blocks","ulids":["01K6G48A5956XVJHVSBMVWB0DR","01K6G4DS329X6QFG7XSHN93VBP","01K6G354WKHPP495KCE647BWA6","01K6D0Y6NZJYH5042GYSW4YQ6R","01K6CQ1EJE38DFJJ2Y1FVWEP7A","01K6D0Y8382CAGYA44SVBNAV6D","01K6D948838S0X8MCH0PM3CJNZ","01K6DQWPBCB3EWCGTCVJWXXTS4","01K6JHD01S79VCQ5R93ECM2DS2","01K6GBJHESTFDTX1DBJJEBVS60","01K6HYV6R35CGPVREBGZCF0480","01K6FGCWVV96ZZ2ND5R9C37EPE","01K6JHD22Y2RP15ADK1HEYD0F5","01K6HYV7Z2CT3K41XYZDBJ9G76","01K6E3XF1AE12MHPZKXG9R0S6A","01K6JHDG3TNYKA33N5VC7KRVBV","01K6GBJKCQBJEVB3Z71YTFV7JW","01K6H2A5XQPC43V900RVX9DYE2","01K6KCB9EN4TR284J0EP9HAQ9B","01K6H29V6GCJSXFYVCFXYK2YPC","01K6HBNEPZTM8SH1CGP6V82HP3","01K6H29H57QP0AZCEKK64ZSA5V","01K6DQX0HC7HP9SMCN6NZ4Y9N5","01K6E8PECDE76MHRESKZSAAGH7","01K6HYV90QXZ2NW0R0FF6XF7QW","01K6DZQEQARSSP8SRN4CZ41795","01K6FGGMQK9TC2F1R33VEFX2N9","01K6JHDMVXRB891SBCFFFKZ8F5","01K6DN2RRH7VJQB8PMHSGD19JZ","01K6KG7SWFZ4CXGK5RN2NXCG6B","01K6JHCK4JDJQK7GGWFYWTC2F6","01K6JHDG3VG1947KDEMTMKXCGH","01K6FGEZSBQHGSV23ZN0B1K08A","01K6DQWEN62FC1XR4SMCR04SJW","01K6JHCNGZMZE73YG7A8HRDQ0V","01K6KNPAM0TCKKAFTWEPQ8NJ2C","01K6JHDQ2J7T7SDTNHFP7N5AB6","01K6JHCTKH0M7XF1WZ802JNSVG","01K6JHD9XY51M9JNDE88XMBWFM","01K6HYV8FKQDSWYM02BAAAYE6P","01K6GP21M1QTFFX7A2CME75CFW","01K6FGEBP28J2PXHGQ5S3FGB5S","01K6HGY5ZSE8Z2VHH70T1SXWZC","01K6CWV17FW6NN4K93NJ5BPJN9","01K6GBJCD08R0S327WS48H8BZG","01K6GBJMSPJJN1CY0AFCKAP796","01K6JHCN19ZXBXTFM715K69170","01K6JHDFYNFDNWHXVNSCQDZS5H","01K6JHCPPZ88Y7JNZ94PFPD3Q8","01K6HBP8P9N6GMV8JSG8DEVHR6","01K6DVKJ7BA1R7W722ZMHF0S6J","01K6JHD01RJHSAW16SZZ25W794","01K6DZQHGYX9CQM8D980CX8K4A","01K6JHCK4PAVXD3DEMZJCKJCN1","01K6DN2Y6GTGF04CKPR39JS6K4","01K6FGBRCXSPHABW766VAP7W75","01K6DVNDAY01Y31V7RPAT3Q4Q6","01K6H29Z05342GGMSW8N2VYBND","01K6JHD22YWEZ40GS7DBPW2WY7","01K6FGC72XZ0VKVDHZWDC2F2HP","01K6DN2M7EKJD4MH621X7788SD","01K6JHCPA01KMZZWSREAS1Q8SY"]}
{"time":"2025-10-23T20:18:19.511525495Z","level":"INFO","msg":"block download start","ulid":"01K6KG7SWFZ4CXGK5RN2NXCG6B"}
{"time":"2025-10-23T20:18:19.511520861Z","level":"INFO","msg":"block download start","ulid":"01K6G4DS329X6QFG7XSHN93VBP"}
{"time":"2025-10-23T20:18:19.511650726Z","level":"INFO","msg":"block download start","ulid":"01K6JHDG3TNYKA33N5VC7KRVBV"}
{"time":"2025-10-23T20:18:19.511748086Z","level":"INFO","msg":"block download start","ulid":"01K6G48A5956XVJHVSBMVWB0DR"}
{"time":"2025-10-23T20:37:37.239844766Z","level":"INFO","msg":"block download complete","ulid":"01K6G48A5956XVJHVSBMVWB0DR"}
{"time":"2025-10-23T20:37:47.309211352Z","level":"INFO","msg":"block download complete","ulid":"01K6KG7SWFZ4CXGK5RN2NXCG6B"}
{"time":"2025-10-23T20:39:25.821067157Z","level":"INFO","msg":"block download complete","ulid":"01K6JHDG3TNYKA33N5VC7KRVBV"}
{"time":"2025-10-23T20:40:27.059425885Z","level":"INFO","msg":"block download complete","ulid":"01K6G4DS329X6QFG7XSHN93VBP"}
```
