### PR TITLE
Fix TestConverterIndexWithManyLabelNames

### DIFF
--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -126,7 +126,6 @@ func TestConverterIndexWithManyLabelNames(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping, because 'short' flag was set")
 	}
-	t.Skip("Expected failure: We dont yet limit the amount of columns we create during conversion")
 
 	// A parquet file can have 32767 columns. We create a column per unique label name
 	// if we have too many unique label names in an index we need to compute its schema


### PR DESCRIPTION
Avoid creating a parquet file with too many columns, the maximum parquet supports is 32767 columns. We will cut more shards to make sure we can accommodate the columns.