### PR TITLE
convert downsampled blocks to parquet

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -226,6 +226,7 @@ type tsdbDiscoveryOpts struct {
 	discoveryMinBlockAge time.Duration
 
 	externalLabelMatchers matcherSlice
+	useDownsampledBlocks  bool
 }
 
 func setupTSDBDiscovery(ctx context.Context, g *run.Group, log *slog.Logger, bkt objstore.Bucket, opts tsdbDiscoveryOpts) (*locate.TSDBDiscoverer, error) {
@@ -234,6 +235,7 @@ func setupTSDBDiscovery(ctx context.Context, g *run.Group, log *slog.Logger, bkt
 		locate.TSDBMetaConcurrency(opts.discoveryConcurrency),
 		locate.TSDBMinBlockAge(opts.discoveryMinBlockAge),
 		locate.TSDBMatchExternalLabels(opts.externalLabelMatchers...),
+		locate.TSDBUseDownsampledBlocks(opts.useDownsampledBlocks),
 	)
 
 	log.Info("Running initial tsdb discovery")

--- a/convert/chunks.go
+++ b/convert/chunks.go
@@ -7,10 +7,14 @@ package convert
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"sort"
 	"time"
 
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
 	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
 
 	"github.com/thanos-io/thanos-parquet-gateway/internal/encoding"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
@@ -49,5 +53,98 @@ func collectChunks(it chunks.Iterator) ([schema.ChunkColumnsPerDay][]byte, error
 		chkBytes = append(chkBytes, bs...)
 		res[chkIdx] = chkBytes
 	}
+	return res, nil
+}
+
+type sample struct {
+	t int64
+	v float64
+}
+
+// expandXorChunkIterator reads all samples from the iterator and appends them to buf.
+// Stale markers and out of order samples are skipped.
+// Copied from pkg/compact/downsample/downsample.go in thanos.
+func expandXorChunkIterator(it chunkenc.Iterator, buf *[]sample) error {
+	// For safety reasons, we check for each sample that it does not go back in time.
+	// If it does, we skip it.
+	lastT := int64(0)
+	for it.Next() != chunkenc.ValNone {
+		t, v := it.At()
+		if value.IsStaleNaN(v) {
+			continue
+		}
+		if t >= lastT {
+			*buf = append(*buf, sample{t: t, v: v})
+			lastT = t
+		}
+	}
+	return it.Err()
+}
+
+type aggregateBytes [5][]byte
+
+// Returns collected downsampled chunks: count, sum, min, max, counter.
+func collectDownsampledChunks(it chunks.Iterator) (aggregateBytes, error) {
+	var (
+		temp [5][]sample
+	)
+	res := aggregateBytes{}
+	chunks := make([]chunks.Meta, 0, 12)
+	for it.Next() {
+		chunks = append(chunks, it.At())
+	}
+	if err := it.Err(); err != nil {
+		return res, fmt.Errorf("unable to iterate chunks: %w", err)
+	}
+	// NOTE: we need to sort chunks here as they come from different blocks that we merged.
+	// Prometheus does not guarantee that they are sorted. We have to sort them either here or
+	// before submitting them to the query engine.
+	sort.Slice(chunks, func(i, j int) bool {
+		return chunks[i].MinTime < chunks[j].MinTime
+	})
+	for _, chk := range chunks {
+		if chk.Chunk.NumSamples() == 0 {
+			continue
+		}
+
+		enc, bs := chk.Chunk.Encoding(), chk.Chunk.Bytes()
+		if enc != downsample.ChunkEncAggr {
+			return res, fmt.Errorf("expected downsample chunk encoding but got %d", enc)
+		}
+
+		ac := downsample.AggrChunk(bs)
+		for _, at := range []downsample.AggrType{downsample.AggrCount, downsample.AggrSum, downsample.AggrMin, downsample.AggrMax, downsample.AggrCounter} {
+			if c, err := ac.Get(at); err != downsample.ErrAggrNotExist {
+				if err != nil {
+					return res, err
+				}
+				err = expandXorChunkIterator(c.Iterator(nil), &temp[at])
+				if err != nil {
+					return res, fmt.Errorf("unable to expand aggregate chunk %d: %w", at, err)
+				}
+			}
+		}
+	}
+
+	for _, aggrType := range []downsample.AggrType{downsample.AggrCount, downsample.AggrSum, downsample.AggrMin, downsample.AggrMax, downsample.AggrCounter} {
+		samples := temp[aggrType]
+		bts := make([]byte, 0)
+		if len(samples) == 0 {
+			continue
+		}
+		bts = binary.BigEndian.AppendUint64(bts, uint64(len(samples)))
+		for _, s := range samples {
+			bts = binary.BigEndian.AppendUint64(bts, uint64(s.t))
+			// For the Count and Counter aggregates, we store integer values.
+			if aggrType == downsample.AggrCount || aggrType == downsample.AggrCounter {
+				bts = binary.BigEndian.AppendUint64(bts, uint64(s.v))
+				continue
+			}
+			// All other aggregates are stored as float64 values.
+			bts = binary.BigEndian.AppendUint64(bts, math.Float64bits(s.v))
+		}
+		res[aggrType] = bts
+	}
+
 	return res, nil
 }

--- a/convert/downsampled_test.go
+++ b/convert/downsampled_test.go
@@ -1,0 +1,452 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package convert
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"maps"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/units"
+	"github.com/go-kit/log"
+	"github.com/parquet-go/parquet-go"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/thanos-io/objstore/providers/filesystem"
+	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
+
+	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
+	"github.com/thanos-io/thanos-parquet-gateway/locate"
+	"github.com/thanos-io/thanos-parquet-gateway/schema"
+)
+
+// createDownsampledBlock is a helper function that creates a raw TSDB block and downsamples it.
+// It returns the downsampled block ready for testing.
+func createDownsampledBlock(t *testing.T, seriesCount, samplesPerSeries int) (*tsdb.Block, func()) {
+	t.Helper()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	dbDir := filepath.Join(tempDir, "raw-db")
+	db, err := tsdb.Open(dbDir, nil, nil, tsdb.DefaultOptions(), nil)
+	if err != nil {
+		t.Fatalf("failed to open TSDB: %v", err)
+	}
+
+	app := db.Appender(ctx)
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).UnixMilli()
+
+	for i := range seriesCount {
+		lbls := labels.FromStrings(
+			"__name__", fmt.Sprintf("test_metric_%d", i),
+			"label1", fmt.Sprintf("value_%d", i),
+			"label2", fmt.Sprintf("value_%d", i),
+		)
+
+		// Add samples at 1-minute intervals
+		for j := range samplesPerSeries {
+			timestamp := baseTime + int64(j*60*1000) // 1 minute intervals
+			value := float64(100 + (i % 2 * 100))    // First series 100, second 200, then 100, 200 etc.
+
+			if _, err := app.Append(0, lbls, timestamp, value); err != nil {
+				t.Fatalf("failed to append sample: %v", err)
+			}
+		}
+	}
+
+	if err := app.Commit(); err != nil {
+		t.Fatalf("failed to commit samples: %v", err)
+	}
+
+	if err := db.Compact(ctx); err != nil {
+		t.Fatalf("failed to compact: %v", err)
+	}
+
+	blocks := db.Blocks()
+	if len(blocks) == 0 {
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close db: %v", err)
+		}
+
+		db, err = tsdb.Open(dbDir, nil, nil, tsdb.DefaultOptions(), nil)
+		if err != nil {
+			t.Fatalf("failed to reopen TSDB: %v", err)
+		}
+
+		blocks = db.Blocks()
+		if len(blocks) == 0 {
+			t.Fatal("no blocks created after compaction and reopen")
+		}
+	}
+
+	rawBlock := blocks[0]
+	t.Logf("Created raw block with %d series, time range: [%d, %d]",
+		rawBlock.Meta().Stats.NumSeries, rawBlock.MinTime(), rawBlock.MaxTime())
+
+	rawMeta := &metadata.Meta{
+		BlockMeta: rawBlock.Meta(),
+		Thanos: metadata.Thanos{
+			Downsample: metadata.ThanosDownsample{
+				Resolution: downsample.ResLevel0, // Raw resolution
+			},
+		},
+	}
+
+	downsampledDir := filepath.Join(tempDir, "downsampled")
+	if err := os.MkdirAll(downsampledDir, 0755); err != nil {
+		t.Fatalf("failed to create downsampled directory: %v", err)
+	}
+
+	logger := log.NewNopLogger()
+	downsampledID, err := downsample.Downsample(
+		ctx,
+		logger,
+		rawMeta,
+		rawBlock,
+		downsampledDir,
+		downsample.ResLevel1, // 5m resolution
+	)
+	if err != nil {
+		t.Fatalf("failed to downsample block: %v", err)
+	}
+
+	downsampledBlockPath := filepath.Join(downsampledDir, downsampledID.String())
+	downsampledBlock, err := tsdb.OpenBlock(nil, downsampledBlockPath, downsample.NewPool(), nil)
+	if err != nil {
+		t.Fatalf("failed to open downsampled block: %v", err)
+	}
+
+	downsampledMeta, err := metadata.ReadFromDir(downsampledBlockPath)
+	if err != nil {
+		t.Fatalf("failed to read downsampled metadata: %v", err)
+	}
+	if downsampledMeta.Thanos.Downsample.Resolution != downsample.ResLevel1 {
+		t.Fatalf("expected downsampled resolution %d, got %d",
+			downsample.ResLevel1, downsampledMeta.Thanos.Downsample.Resolution)
+	}
+	t.Logf("Successfully created downsampled block with resolution: %d", downsampledMeta.Thanos.Downsample.Resolution)
+
+	cleanup := func() {
+		// Close the block first, then close the DB
+		// Note: The caller should close any readers before calling cleanup
+		if err := downsampledBlock.Close(); err != nil {
+			t.Logf("error closing downsampled block: %v", err)
+		}
+		if err := db.Close(); err != nil {
+			t.Logf("error closing db: %v", err)
+		}
+	}
+
+	return downsampledBlock, cleanup
+}
+
+func TestReadingDownsampledWithShardedIndexRowReader(t *testing.T) {
+	ctx := t.Context()
+	seriesCount := 2
+	samplesPerSeries := 1000
+
+	downsampledBlock, cleanup := createDownsampledBlock(t, seriesCount, samplesPerSeries)
+	defer cleanup()
+
+	mint := downsampledBlock.MinTime()
+	maxt := downsampledBlock.MaxTime()
+
+	cfg := convertOpts{
+		rowGroupSize:        1_000_000,
+		numRowGroups:        6,
+		sortingColumns:      [][]string{{schema.LabelNameToColumn(labels.MetricName)}},
+		bloomfilterColumns:  [][]string{{schema.LabelNameToColumn(labels.MetricName)}},
+		labelBufferPool:     parquet.NewBufferPool(),
+		chunkbufferPool:     parquet.NewBufferPool(),
+		encodingConcurrency: 1,
+		labelPageBufferSize: int(256 * units.KiB),
+		chunkPageBufferSize: int(2 * units.MiB),
+		writeConcurrency:    1,
+		downsampled:         true,
+	}
+
+	readers, err := shardedIndexRowReader(ctx, mint, maxt, []Convertible{downsampledBlock}, cfg)
+	if err != nil {
+		t.Fatalf("failed to create sharded index row reader: %v", err)
+	}
+
+	if len(readers) != 1 {
+		t.Fatalf("expected 1 sharded reader, got %d", len(readers))
+	}
+
+	reader := readers[0]
+	defer reader.Close()
+
+	if reader.schema == nil {
+		t.Fatal("expected schema to be non-nil")
+	}
+
+	if reader.rowBuilder == nil {
+		t.Fatal("expected rowBuilder to be non-nil")
+	}
+
+	if reader.concurrency != cfg.encodingConcurrency {
+		t.Fatalf("expected concurrency %d, got %d", cfg.encodingConcurrency, reader.concurrency)
+	}
+
+	// Test reading rows from the downsampled block
+	buf := make([]parquet.Row, 2)
+	n, err := reader.ReadRows(buf)
+	if err != nil && err != io.EOF {
+		t.Fatalf("failed to read rows: %v", err)
+	}
+
+	if n != 2 {
+		t.Fatalf("expected to read at two rows, got %v", n)
+	}
+
+	t.Logf("Successfully read %d rows from downsampled block", n)
+
+	expectedValues := [][]float64{
+		// Indexed by downsample.AggrType: AggrCount, AggrSum, AggrMin, AggrMax, AggrCounter
+		{5, 500.0, 100.0, 100.0, 100.0},  // First row expected aggregates
+		{5, 1000.0, 200.0, 200.0, 200.0}, // Second row expected aggregates
+	}
+
+	// Verify the rows have the expected structure
+	for i := range n {
+		row := buf[i]
+		if len(row) == 0 {
+			t.Fatalf("row %d is empty", i)
+		}
+
+		// Check for required columns
+		hasLabelHash := false
+		hasLabelIndex := false
+		hasAggregateColumns := false
+
+		for _, val := range row {
+			colName := reader.schema.Columns()[val.Column()][0]
+			if colName == schema.LabelHashColumn {
+				hasLabelHash = true
+			}
+			if colName == schema.LabelIndexColumn {
+				hasLabelIndex = true
+			}
+			if colName == schema.CountColumn ||
+				colName == schema.SumColumn ||
+				colName == schema.MinColumn ||
+				colName == schema.MaxColumn ||
+				colName == schema.CounterColumn {
+				hasAggregateColumns = true
+			}
+		}
+
+		if !hasLabelHash {
+			t.Errorf("row %d missing label hash column", i)
+		}
+		if !hasLabelIndex {
+			t.Errorf("row %d missing label index column", i)
+		}
+		if !hasAggregateColumns {
+			t.Errorf("row %d missing aggregate columns", i)
+		}
+
+		row.Range(func(columnIndex int, columnValues []parquet.Value) bool {
+			colName := reader.schema.Columns()[columnIndex][0]
+
+			switch colName {
+			case schema.CountColumn:
+				checkSamples(t, columnValues[0].ByteArray(), downsample.AggrCount, expectedValues[i][downsample.AggrCount])
+			case schema.CounterColumn:
+				checkSamples(t, columnValues[0].ByteArray(), downsample.AggrCounter, expectedValues[i][downsample.AggrCounter])
+			case schema.MaxColumn:
+				checkSamples(t, columnValues[0].ByteArray(), downsample.AggrMax, expectedValues[i][downsample.AggrMax])
+			case schema.MinColumn:
+				checkSamples(t, columnValues[0].ByteArray(), downsample.AggrMin, expectedValues[i][downsample.AggrMin])
+			case schema.SumColumn:
+				checkSamples(t, columnValues[0].ByteArray(), downsample.AggrSum, expectedValues[i][downsample.AggrSum])
+			}
+
+			return true
+		})
+
+	}
+
+	// Test that schema contains expected columns
+	schemaColumns := reader.schema.Columns()
+	if len(schemaColumns) == 0 {
+		t.Fatal("schema has no columns")
+	}
+
+	// Verify all columns exist
+	if _, ok := reader.schema.Lookup(schema.LabelHashColumn); !ok {
+		t.Errorf("schema missing %s", schema.LabelHashColumn)
+	}
+	if _, ok := reader.schema.Lookup(schema.LabelIndexColumn); !ok {
+		t.Errorf("schema missing %s", schema.LabelIndexColumn)
+	}
+	for _, col := range []string{
+		schema.SumColumn,
+		schema.MinColumn,
+		schema.MaxColumn,
+		schema.CounterColumn,
+	} {
+		if _, ok := reader.schema.Lookup(col); !ok {
+			t.Errorf("schema missing %s", col)
+		}
+	}
+}
+
+func convertSamples(t *testing.T, bts []byte, aggrType downsample.AggrType) []sample {
+	values, err := BinarySamplesToString(bts, aggrType)
+	if err != nil {
+		t.Errorf("failed to get samples for aggrType %v: %v", aggrType, err)
+	}
+	return values
+}
+
+func checkSamples(t *testing.T, bts []byte, aggrType downsample.AggrType, expectedValue float64) {
+	values := convertSamples(t, bts, aggrType)
+
+	for _, s := range values {
+		if s.v != expectedValue {
+			t.Errorf("expected value %f, got %f at timestamp %d for aggrType %v", expectedValue, s.v, s.t, aggrType)
+		}
+	}
+}
+
+func BinarySamplesToString(bs []byte, aggrType downsample.AggrType) ([]sample, error) {
+	length := binary.BigEndian.Uint64(bs[:8])
+	bs = bs[8:]
+
+	parts := make([]sample, 0, length)
+
+	for len(bs) != 0 {
+		timestamp := binary.BigEndian.Uint64(bs[:8])
+		bs = bs[8:]
+
+		value := binary.BigEndian.Uint64(bs[:8])
+		bs = bs[8:]
+
+		if aggrType == downsample.AggrCount || aggrType == downsample.AggrCounter {
+			parts = append(parts, sample{t: int64(timestamp), v: float64(value)})
+			continue
+		}
+		// For other aggregates, decode float64 value.
+		floatValue := math.Float64frombits(value)
+		if math.IsNaN(floatValue) {
+			// Make this an error?
+			parts = append(parts, sample{t: int64(timestamp), v: math.NaN()})
+		} else {
+			parts = append(parts, sample{t: int64(timestamp), v: floatValue})
+		}
+	}
+
+	return parts, nil
+}
+
+func TestConversionOfDownsampled(t *testing.T) {
+	bkt, err := filesystem.NewBucket(t.TempDir())
+	if err != nil {
+		t.Fatalf("unable to create bucket: %s", err)
+	}
+	t.Cleanup(func() { _ = bkt.Close() })
+
+	downsampledBlock, cleanup := createDownsampledBlock(t, 10, 1000)
+	defer cleanup()
+	startTime := util.NewDate(2024, 1, 1)
+
+	opts := []ConvertOption{
+		SortBy(labels.MetricName),
+		RowGroupSize(250),
+		RowGroupCount(2),
+		LabelPageBufferSize(units.KiB), // results in 2 pages
+		Downsampled(true),
+	}
+	if err := ConvertTSDBBlock(t.Context(), bkt, startTime, []Convertible{downsampledBlock}, opts...); err != nil {
+		t.Fatalf("unable to convert tsdb block: %s", err)
+	}
+
+	// Check contents of bucket
+	discoverer := locate.NewDiscoverer(bkt)
+	if err := discoverer.Discover(t.Context()); err != nil {
+		t.Fatalf("unable to convert parquet block: %s", err)
+	}
+	metas := discoverer.Metas()
+
+	if n := len(metas); n != 1 {
+		t.Fatalf("unexpected number of metas: %d", n)
+	}
+	meta := metas[slices.Collect(maps.Keys(metas))[0]]
+
+	if n := meta.Shards; n != 1 {
+		t.Fatalf("unexpected number of shards: %d", n)
+	}
+
+	totalRows := int64(0)
+	for i := range int(meta.Shards) {
+		lf, err := loadParquetFile(t.Context(), bkt, schema.LabelsPfileNameForShard(meta.Name, i))
+		if err != nil {
+			t.Fatalf("unable to load label parquet file for shard %d: %s", i, err)
+		}
+		cf, err := loadParquetFile(t.Context(), bkt, schema.ChunksPfileNameForShard(meta.Name, i))
+		if err != nil {
+			t.Fatalf("unable to load chunk parquet file for shard %d: %s", i, err)
+		}
+		if cf.NumRows() != lf.NumRows() {
+			t.Fatalf("labels and chunk file have different numbers of rows for shard %d", i)
+		}
+		totalRows += lf.NumRows()
+
+		for _, rg := range cf.RowGroups() {
+			r := rg.Rows()
+			rows := make([]parquet.Row, 10)
+			n, err := r.ReadRows(rows)
+			if err != nil && err != io.EOF {
+				t.Fatalf("unable to read rows from chunk file for shard %d: %s", i, err)
+			}
+			if err == io.EOF && n == 0 {
+				continue
+			}
+			for j := 0; j < n; j++ {
+				row := rows[j]
+				row.Range(func(columnIndex int, columnValues []parquet.Value) bool {
+					colName := cf.Schema().Columns()[columnIndex][0]
+					var count int
+					var skip bool
+					switch colName {
+					case schema.CountColumn:
+						count = len(convertSamples(t, columnValues[0].ByteArray(), downsample.AggrCount))
+					case schema.CounterColumn:
+						count = len(convertSamples(t, columnValues[0].ByteArray(), downsample.AggrCounter))
+					case schema.MaxColumn:
+						count = len(convertSamples(t, columnValues[0].ByteArray(), downsample.AggrMax))
+					case schema.MinColumn:
+						count = len(convertSamples(t, columnValues[0].ByteArray(), downsample.AggrMin))
+					case schema.SumColumn:
+						count = len(convertSamples(t, columnValues[0].ByteArray(), downsample.AggrSum))
+					case schema.LabelHashColumn, schema.LabelIndexColumn, schema.LabelColumnPrefix:
+						skip = true
+					default:
+						t.Fatalf("unexpected column %s", colName)
+					}
+
+					if !skip && count == 0 {
+						t.Fatalf("no samples found in column %s", colName)
+					}
+					return true
+				})
+			}
+		}
+	}
+	if totalRows != int64(10) {
+		t.Fatalf("too few rows: %d", totalRows)
+	}
+}

--- a/convert/tsdb.go
+++ b/convert/tsdb.go
@@ -9,13 +9,20 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/parquet-go/parquet-go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	"github.com/prometheus/prometheus/tsdb/tombstones"
+	"github.com/prometheus/prometheus/util/annotations"
 
 	"github.com/thanos-io/thanos-parquet-gateway/internal/encoding"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
+	"github.com/thanos-io/thanos/pkg/compact/downsample"
 )
 
 type indexRowReader struct {
@@ -25,8 +32,10 @@ type indexRowReader struct {
 
 	seriesSet storage.ChunkSeriesSet
 
-	schema     *parquet.Schema
-	rowBuilder *parquet.RowBuilder
+	schema           *parquet.Schema
+	chunksProjection schema.Projection
+	labelsProjection schema.Projection
+	rowBuilder       *parquet.RowBuilder
 
 	concurrency int
 
@@ -35,11 +44,14 @@ type indexRowReader struct {
 	chunksColumn2    int
 	labelIndexColumn int
 	labelHashColumn  int
-}
 
-type indexReaderOpts struct {
-	sortLabels  []string
-	concurrency int
+	countColumn   int
+	sumColumn     int
+	minColumn     int
+	maxColumn     int
+	counterColumn int
+
+	downsampled bool
 }
 
 var _ parquet.RowReader = &indexRowReader{}
@@ -64,6 +76,106 @@ func (rr *indexRowReader) Schema() *parquet.Schema {
 }
 
 func (rr *indexRowReader) ReadRows(buf []parquet.Row) (int, error) {
+	if rr.downsampled {
+		return rr.readDownsampledRows(buf)
+	}
+	return rr.readNonDownsampledRows(buf)
+}
+
+func (rr *indexRowReader) readDownsampledRows(buf []parquet.Row) (int, error) {
+	select {
+	case <-rr.ctx.Done():
+		return 0, rr.ctx.Err()
+	default:
+	}
+
+	// Same as other but with downsampled chunk collection.
+	type chunkAggregatesOrError struct {
+		res aggregateBytes
+
+		err error
+	}
+	type chunkSeriesPromise struct {
+		s storage.ChunkSeries
+		c chan chunkAggregatesOrError
+	}
+
+	chunkSeriesC := make(chan chunkSeriesPromise, rr.concurrency)
+
+	go func() {
+		defer close(chunkSeriesC)
+		for j := 0; j < len(buf) && rr.seriesSet.Next(); j++ {
+			s := rr.seriesSet.At()
+			it := s.Iterator(nil)
+
+			promise := chunkSeriesPromise{
+				s: s,
+				c: make(chan chunkAggregatesOrError, 1),
+			}
+
+			chunkSeriesC <- promise
+
+			go func() {
+				res, err := collectDownsampledChunks(it)
+				promise.c <- chunkAggregatesOrError{res: res, err: err}
+				close(promise.c)
+			}()
+		}
+	}()
+
+	colIdxSlice := make([]int, 0)
+	i, j := 0, 0
+	for promise := range chunkSeriesC {
+		j++
+
+		rr.rowBuilder.Reset()
+		colIdxSlice = colIdxSlice[:0]
+
+		chkAggregatesOrError := <-promise.c
+		if err := chkAggregatesOrError.err; err != nil {
+			return i, err
+		}
+		res := chkAggregatesOrError.res
+		chkLbls := promise.s.Labels()
+
+		chkLbls.Range(func(l labels.Label) {
+			colName := schema.LabelNameToColumn(l.Name)
+			lc, _ := rr.schema.Lookup(colName)
+			rr.rowBuilder.Add(lc.ColumnIndex, parquet.ValueOf(l.Value))
+			colIdxSlice = append(colIdxSlice, lc.ColumnIndex-schema.ChunkColumnsPerDay)
+		})
+		rr.rowBuilder.Add(rr.labelIndexColumn, parquet.ValueOf(encoding.EncodeLabelColumnIndex(colIdxSlice)))
+		rr.rowBuilder.Add(rr.labelHashColumn, parquet.ValueOf(chkLbls.Hash()))
+
+		if allAggregatesEmpty(res) {
+			continue
+		}
+
+		// Use a byte array and store all the samples, with timestamps and values
+		rr.rowBuilder.Add(rr.countColumn, parquet.ValueOf(res[downsample.AggrCount]))
+		rr.rowBuilder.Add(rr.sumColumn, parquet.ValueOf(res[downsample.AggrSum]))
+		rr.rowBuilder.Add(rr.minColumn, parquet.ValueOf(res[downsample.AggrMin]))
+		rr.rowBuilder.Add(rr.maxColumn, parquet.ValueOf(res[downsample.AggrMax]))
+		rr.rowBuilder.Add(rr.counterColumn, parquet.ValueOf(res[downsample.AggrCounter]))
+		buf[i] = rr.rowBuilder.AppendRow(buf[i][:0])
+		i++
+	}
+	if j < len(buf) {
+		return i, io.EOF
+	}
+	return i, rr.seriesSet.Err()
+}
+
+func allAggregatesEmpty(aggBytes aggregateBytes) bool {
+	for _, chk := range aggBytes {
+		if len(chk) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (rr *indexRowReader) readNonDownsampledRows(buf []parquet.Row) (int, error) {
 	select {
 	case <-rr.ctx.Done():
 		return 0, rr.ctx.Err()
@@ -160,4 +272,145 @@ func allChunksEmpty(chkBytes [schema.ChunkColumnsPerDay][]byte) bool {
 		}
 	}
 	return true
+}
+
+type downsampledSeries struct {
+	lset  labels.Labels
+	metas []chunks.Meta
+}
+
+func (d *downsampledSeries) Labels() labels.Labels {
+	return d.lset
+}
+
+func (d *downsampledSeries) Iterator(it chunks.Iterator) chunks.Iterator {
+	if dsit, ok := it.(*downsampledSeriesIterator); ok {
+		dsit.metas = d.metas
+		dsit.i = -1
+		return dsit
+	}
+	return &downsampledSeriesIterator{metas: d.metas, i: -1}
+}
+
+type downsampledSeriesIterator struct {
+	metas []chunks.Meta
+	i     int
+}
+
+func (it *downsampledSeriesIterator) Next() bool {
+	it.i++
+	return it.i < len(it.metas)
+}
+
+func (it *downsampledSeriesIterator) At() chunks.Meta {
+	return it.metas[it.i]
+}
+
+func (it *downsampledSeriesIterator) Err() error {
+	return nil
+}
+
+type concatChunkSeriesSet struct {
+	series []storage.ChunkSeries
+	idx    int
+}
+
+func newConcatChunkSeriesSet(series ...storage.ChunkSeries) storage.ChunkSeriesSet {
+	return &concatChunkSeriesSet{series: series, idx: -1}
+}
+
+func (c *concatChunkSeriesSet) Next() bool {
+	c.idx++
+	return c.idx < len(c.series)
+}
+
+func (c *concatChunkSeriesSet) At() storage.ChunkSeries {
+	return c.series[c.idx]
+}
+
+func (c *concatChunkSeriesSet) Err() error {
+	return nil
+}
+
+func (c *concatChunkSeriesSet) Warnings() annotations.Annotations {
+	return nil
+}
+
+func buildDownsampledSeriesSet(ctx context.Context, indexr tsdb.IndexReader, chunkr tsdb.ChunkReader, tombsr tombstones.Reader, mint, maxt int64, sortFn func(a, b labels.Labels) int) (storage.ChunkSeriesSet, error) {
+	postings := tsdb.AllSortedPostings(ctx, indexr)
+	lb := labels.NewScratchBuilder(16)
+	series := make([]storage.ChunkSeries, 0, 1024)
+	for postings.Next() {
+		ref := postings.At()
+		lb.Reset()
+		var metas []chunks.Meta
+		if err := indexr.Series(ref, &lb, &metas); err != nil {
+			return nil, fmt.Errorf("series expansion: %w", err)
+		}
+		full := make([]chunks.Meta, 0, len(metas))
+		for _, m := range metas {
+			if m.MaxTime < mint || m.MinTime > maxt {
+				continue
+			}
+			// Load chunk bytes or subset via ChunkOrIterable.
+			ch, iterable, cerr := chunkr.ChunkOrIterable(m)
+			if cerr != nil {
+				// log skip verbose
+				// fmt.Printf("downsample: skip chunk ref=%d err=%v\n", m.Ref, cerr)
+				continue // skip unreadable
+			}
+			if iterable != nil {
+				// Materialize samples from iterable into a single XOR chunk.
+				it := iterable.Iterator(nil)
+				xc := chunkenc.NewXORChunk()
+				app, _ := xc.Appender()
+				var smint, smaxt int64
+				first := true
+				for vt := it.Next(); vt != chunkenc.ValNone; vt = it.Next() {
+					if vt != chunkenc.ValFloat { // skip non-float samples (histograms) for now
+						continue
+					}
+					ts, v := it.At()
+					if first {
+						smint = ts
+						first = false
+					}
+					smaxt = ts
+					app.Append(ts, v)
+				}
+				if it.Err() == nil && !first {
+					full = append(full, chunks.Meta{MinTime: smint, MaxTime: smaxt, Chunk: xc})
+				}
+				continue
+			}
+			// Normal chunk path.
+			full = append(full, chunks.Meta{MinTime: m.MinTime, MaxTime: m.MaxTime, Chunk: ch})
+		}
+		// Tombstone filtering if available.
+		if tombsr != nil {
+			filtered := full[:0]
+			ivs, terr := tombsr.Get(ref)
+			if terr == nil && len(ivs) > 0 {
+				for _, cm := range full {
+					covered := false
+					for _, iv := range ivs {
+						if cm.MinTime <= iv.Maxt && iv.Mint <= cm.MaxTime {
+							covered = true
+							break
+						}
+					}
+					if !covered {
+						filtered = append(filtered, cm)
+					}
+				}
+				full = filtered
+			}
+		}
+		series = append(series, &downsampledSeries{lset: lb.Labels(), metas: full})
+	}
+	if err := postings.Err(); err != nil {
+		return nil, fmt.Errorf("postings error: %w", err)
+	}
+	slices.SortFunc(series, func(a, b storage.ChunkSeries) int { return sortFn(a.Labels(), b.Labels()) })
+	return newConcatChunkSeriesSet(series...), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.2
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/KimMachineGun/automemlimit v0.7.3
+	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/json-iterator/go v1.1.12
@@ -26,7 +27,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.36.0
 	google.golang.org/protobuf v1.36.9
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -36,7 +36,6 @@ require (
 	github.com/efficientgo/tools/extkingpin v0.0.0-20230505153745-6b7392939a60 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
@@ -103,6 +102,7 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go4.org/intern v0.0.0-20230525184215-6c62f75575cb // indirect
 	go4.org/unsafe/assume-no-moving-gc v0.0.0-20231121144256-b99613f794b6 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 


### PR DESCRIPTION
This PR adds new functionality to the indexRowReader to read a downsampled block and convert it into a parquet file. A new parquet schema is used. This has columns for the count, sum, min, max and counter columns in the downsampled block. Per row it holds multiple value for each of these fields in a ByteArray.

The fields contain the length first as a binary encoded uint64. Then for each sample the timestamps is stored in a uint64 followed by either a uint64 (for count and counter) or float64 encoded as uint64 (for the other columns) for the value. See collectDownsampledChunks in chunks.go for the details.

This mode is enabled by the tsdb.discovery.use-downsampled flag. If this is specified only downsampled blocks are located and processed. Our use case at the moment is to convert older downsampled blocks.

Unit tests that create local downsampled files are added.