### PR TITLE
convert: flush split pipe bufio.Writer on Close

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -720,10 +720,8 @@ func (s *splitPipeFileWriter) Close() error {
 		if err := fw.pw.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("unable to close pipewriter: %w", err))
 		}
-		if fw.bw != nil {
-			if err := fw.bw.Flush(); err != nil {
-				errs = append(errs, fmt.Errorf("unable to flush buffered writer: %w", err))
-			}
+		if err := fw.bw.Flush(); err != nil {
+			errs = append(errs, fmt.Errorf("unable to flush buffered writer: %w", err))
 		}
 		if err := fw.w.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("unable to close writer: %w", err))


### PR DESCRIPTION
The fileWriter uses a bufio.Writer (bw) with a 32MB buffer on top of an io.PipeWriter (w).
1. fw.pw (Parquet writer) writes to fw.bw.
2. When fw.pw.Close() is called, it writes the Parquet footer to fw.bw.
3. Before the fix: The code immediately called fw.w.Close(). If the buffer in fw.bw wasn't full, the footer would sit in memory. fw.w.Close() would close the pipe, signaling EOF to the reader side (bkt.Upload), which would finish reading without receiving the footer. This results in a corrupted/truncated Parquet file.
4. With the fix: fw.bw.Flush() is explicitly called after fw.pw.Close() and before fw.w.Close(). This forces all buffered data (including the footer) into the pipe, ensuring the reader receives the complete file.
