### PR TITLE
db: wire external labels to info server

### DIFF
--- a/api/grpc/thanos_test.go
+++ b/api/grpc/thanos_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package grpc
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/thanos-parquet-gateway/db"
+	"github.com/thanos-io/thanos-parquet-gateway/schema"
+	"github.com/thanos-io/thanos/pkg/info/infopb"
+	"github.com/thanos-io/thanos/pkg/store/labelpb"
+)
+
+type mockParquetDB struct {
+	blocks []db.BlockInfo
+
+	overrideExtLabels labels.Labels
+}
+
+var _ parquetDatabase = (*mockParquetDB)(nil)
+
+func (m *mockParquetDB) Timerange() (int64, int64) {
+	var mint, maxt = int64(math.MaxInt64), int64(math.MinInt64)
+	for _, b := range m.blocks {
+		mint = min(mint, b.MinT)
+		maxt = max(maxt, b.MaxT)
+	}
+	return mint, maxt
+}
+
+func (m *mockParquetDB) BlockStreams() map[schema.ExternalLabelsHash]db.BlockInfo {
+	streams := make(map[schema.ExternalLabelsHash]db.BlockInfo)
+	for _, b := range m.blocks {
+		st, ok := streams[b.Labels.Hash()]
+		if ok {
+			st.MinT = min(st.MinT, b.MinT)
+			st.MaxT = max(st.MaxT, b.MaxT)
+			streams[b.Labels.Hash()] = st
+			continue
+		}
+		streams[b.Labels.Hash()] = b
+	}
+	return streams
+}
+
+func (m *mockParquetDB) OverrideExtLabels() labels.Labels {
+	return m.overrideExtLabels
+}
+
+func (m *mockParquetDB) Queryable(_ ...db.QueryableOption) *db.DBQueryable {
+	return nil
+}
+
+func TestQueryServerInfo(t *testing.T) {
+	t.Run("overridden ext labels", func(t *testing.T) {
+		qs := &QueryServer{
+			db: &mockParquetDB{
+				overrideExtLabels: labels.FromStrings("cluster", "us-central1", "replica", "01"),
+				blocks: []db.BlockInfo{
+					{
+						MinT:   100,
+						MaxT:   200,
+						Labels: schema.ExternalLabels{"not": "visible"},
+					},
+					{
+						MinT: 50,
+						MaxT: 250,
+					},
+				},
+			},
+		}
+
+		resp, err := qs.Info(context.Background(), &infopb.InfoRequest{})
+		require.NoError(t, err)
+		require.Equal(t, int64(50), resp.Store.MinTime)
+		require.Equal(t, int64(250), resp.Store.MaxTime)
+		require.Equal(t, []labelpb.ZLabelSet{{
+			Labels: []labelpb.ZLabel{
+				{Name: "cluster", Value: "us-central1"},
+				{Name: "replica", Value: "01"},
+			},
+		}}, resp.LabelSets)
+	})
+
+	t.Run("blocks based info", func(t *testing.T) {
+		qs := &QueryServer{
+			db: &mockParquetDB{
+				overrideExtLabels: labels.FromStrings(),
+				blocks: []db.BlockInfo{
+					{
+						MinT:   100,
+						MaxT:   200,
+						Labels: schema.ExternalLabels{"iam": "visible"},
+					},
+					{
+						MinT:   50,
+						MaxT:   250,
+						Labels: schema.ExternalLabels{"me": "too"},
+					},
+				},
+			},
+		}
+
+		resp, err := qs.Info(context.Background(), &infopb.InfoRequest{})
+		require.NoError(t, err)
+		require.Equal(t, int64(50), resp.Store.MinTime)
+		require.Equal(t, int64(250), resp.Store.MaxTime)
+		require.Equal(t, []labelpb.ZLabelSet{
+			{
+				Labels: []labelpb.ZLabel{
+					{Name: "iam", Value: "visible"},
+				},
+			},
+			{
+				Labels: []labelpb.ZLabel{
+					{Name: "me", Value: "too"},
+				},
+			},
+		}, resp.LabelSets)
+	})
+}

--- a/db/shard.go
+++ b/db/shard.go
@@ -25,10 +25,9 @@ import (
 )
 
 type Shard struct {
-	meta        schema.Meta
-	extLabels   labels.Labels
 	chunkspfile *parquet.File
 	labelspfile *parquet.File
+	meta        schema.Meta
 
 	chunkFileReaderFromCtx func(ctx context.Context) io.ReaderAt
 }
@@ -38,11 +37,9 @@ func NewShard(
 	chunkspfile *parquet.File,
 	labelspfile *parquet.File,
 	chunkFileReaderCtxFunc func(ctx context.Context) io.ReaderAt,
-	extLabels schema.ExternalLabels,
 ) *Shard {
 	return &Shard{
 		meta:                   meta,
-		extLabels:              labels.FromMap(extLabels),
 		chunkspfile:            chunkspfile,
 		labelspfile:            labelspfile,
 		chunkFileReaderFromCtx: chunkFileReaderCtxFunc,
@@ -50,7 +47,7 @@ func NewShard(
 }
 
 func (shd *Shard) Queryable(
-	overrideExtLabels labels.Labels,
+	extLabels labels.Labels,
 	replicaLabelNames []string,
 	selectChunkBytesQuota *limits.Quota,
 	selectRowCountQuota *limits.Quota,
@@ -61,12 +58,8 @@ func (shd *Shard) Queryable(
 	labelValuesRowCountQuota *limits.Quota,
 	labelNamesRowCountQuota *limits.Quota,
 ) *ShardQueryable {
-	extLbls := shd.extLabels
-	if overrideExtLabels.Len() > 0 {
-		extLbls = overrideExtLabels
-	}
 	return &ShardQueryable{
-		extlabels:                          extLbls,
+		extlabels:                          extLabels,
 		replicaLabelNames:                  replicaLabelNames,
 		selectChunkBytesQuota:              selectChunkBytesQuota,
 		selectRowCountQuota:                selectRowCountQuota,


### PR DESCRIPTION
Expose external labels of each stream to the info server. Refactor the code a little bit - shard functions do not need to know about the external labels, only the hashes to be able to form the path from where to read them. As before, if some external labels were set manually then they override what has been found.

Related to #25. Last missing part: error out if hash collisions are detected.

Example (I updated the component type during the making of this screenshot):

<img width="2075" height="214" alt="image" src="https://github.com/user-attachments/assets/8ed1a9bf-39c5-41c8-a0d8-3887a70f7991" />

