### PR TITLE
convert: skip empty blocks

### DIFF
--- a/locate/discover.go
+++ b/locate/discover.go
@@ -532,6 +532,11 @@ func (s *TSDBDiscoverer) Discover(ctx context.Context) error {
 		return v.Thanos.Downsample.Resolution != downsample.ResLevel0
 	})
 
+	// filter out blocks with no chunks (cannot be converted)
+	maps.DeleteFunc(nm, func(_ string, v metadata.Meta) bool {
+		return v.Stats.NumChunks == 0
+	})
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/locate/discover_test.go
+++ b/locate/discover_test.go
@@ -170,7 +170,8 @@ func TestTSDBDiscoverer(t *testing.T) {
 		for _, m := range []metadata.Meta{
 			{
 				BlockMeta: tsdb.BlockMeta{
-					ULID: ulid.MustParse("01JS0DPYGA1HPW5RBZ1KBXCNXK"),
+					ULID:  ulid.MustParse("01JS0DPYGA1HPW5RBZ1KBXCNXK"),
+					Stats: tsdb.BlockStats{NumChunks: 1},
 				},
 				Thanos: metadata.Thanos{
 					Labels: map[string]string{
@@ -180,7 +181,8 @@ func TestTSDBDiscoverer(t *testing.T) {
 			},
 			{
 				BlockMeta: tsdb.BlockMeta{
-					ULID: ulid.MustParse("01JT0DPYGA1HPW5RBZ1KBXCNXK"),
+					ULID:  ulid.MustParse("01JT0DPYGA1HPW5RBZ1KBXCNXK"),
+					Stats: tsdb.BlockStats{NumChunks: 1},
 				},
 				Thanos: metadata.Thanos{
 					Labels: map[string]string{
@@ -220,7 +222,8 @@ func TestTSDBDiscoverer(t *testing.T) {
 
 		meta := metadata.Meta{
 			BlockMeta: tsdb.BlockMeta{
-				ULID: ulid.MustParse("01JS0DPYGA1HPW5RBZ1KBXCNXK"),
+				ULID:  ulid.MustParse("01JS0DPYGA1HPW5RBZ1KBXCNXK"),
+				Stats: tsdb.BlockStats{NumChunks: 1},
 			},
 			Thanos: metadata.Thanos{
 				Labels: map[string]string{
@@ -260,7 +263,8 @@ func TestTSDBDiscoverer(t *testing.T) {
 
 		meta := metadata.Meta{
 			BlockMeta: tsdb.BlockMeta{
-				ULID: ulid.MustParse("01JS0DPYGA1HPW5RBZ1KBXCNXK"),
+				ULID:  ulid.MustParse("01JS0DPYGA1HPW5RBZ1KBXCNXK"),
+				Stats: tsdb.BlockStats{NumChunks: 1},
 			},
 		}
 		buf := bytes.NewBuffer(nil)


### PR DESCRIPTION
Currently converter gets stuck if a block is empty, and it just keeps retrying that block over and over