### PR TITLE
fix: error out on stream.pb upload if hash collisions are detected

### DIFF
--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,12 +269,50 @@ func advanceConversion(
 			closeBlocks(log, stepBlocks...)
 			return fmt.Errorf("unable to convert blocks for date %q: %s", step.Date, err)
 		}
-		streamHashMap[step.ExternalLabels.Hash()] = step.ExternalLabels
 
-		if err := convert.WriteStreamDescriptorFile(ctx, log, parquetBkt, step.ExternalLabels, streamHashMap); err != nil {
+		// Checking for hash collisions:
+		// If a discovered stream has different labels than the new stream with the same hash
+		// we panic. If it has the same labels, we can just return nil as it is already uploaded.
+		//
+		// If a new stream is being written, it won't be in the streamHashMap so we still need to
+		// 1. Check if it exists in the bucket in case another converter uploaded after we called
+		// discoverer.Streams()
+		// 2a. If stream file does not exist, just upload.
+		// 2b. If stream file exists and labels are not equal - panic, otherwise,
+		// proceed with the upload.
+		extLabelHash := step.ExternalLabels.Hash()
+		filename := schema.StreamDescriptorFileNameForBlock(extLabelHash)
+		if foundExtLabels, ok := streamHashMap[extLabelHash]; ok {
+			if !maps.Equal(step.ExternalLabels, foundExtLabels) {
+				panic("BUG/TODO: possible hash collision found while uploading stream file; we do not handle this at the moment")
+			}
+
+			streamHashMap[step.ExternalLabels.Hash()] = step.ExternalLabels
+			log.Info("Conversion completed", slog.String("date", step.Date.String()))
+
+			prevBlocks = stepBlocks
+			continue
+		}
+
+		exists, err := parquetBkt.Exists(ctx, filename)
+		if err != nil {
+			return fmt.Errorf("failed to check if file exists in bucket: %w", err)
+		}
+		if exists {
+			sdfile, err := locate.ReadStreamDescriptorFile(ctx, parquetBkt, extLabelHash, log)
+			if err != nil {
+				return fmt.Errorf("failed to read stream descriptor from bucket: %w", err)
+			}
+			if !maps.Equal(sdfile.ExternalLabels, step.ExternalLabels) {
+				panic("BUG/TODO: hash collision found while uploading stream file; we do not handle this at the moment")
+			}
+		}
+
+		if err := convert.WriteStreamDescriptorFile(ctx, parquetBkt, step.ExternalLabels); err != nil {
 			closeBlocks(log, stepBlocks...)
 			return fmt.Errorf("unable to write stream file: %w", err)
 		}
+		streamHashMap[step.ExternalLabels.Hash()] = step.ExternalLabels
 		log.Info("Conversion completed", slog.String("date", step.Date.String()))
 
 		prevBlocks = stepBlocks

--- a/convert/convert.go
+++ b/convert/convert.go
@@ -11,12 +11,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"maps"
 	"math"
 	"slices"
 	"strings"
-	"sync"
 
 	"golang.org/x/sync/errgroup"
 
@@ -34,14 +32,11 @@ import (
 	"github.com/thanos-io/objstore"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/thanos-io/thanos-parquet-gateway/internal/slogerrcapture"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
 	"github.com/thanos-io/thanos-parquet-gateway/proto/metapb"
 	"github.com/thanos-io/thanos-parquet-gateway/proto/streampb"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
 )
-
-var bufPool sync.Pool
 
 type Convertible interface {
 	Index() (tsdb.IndexReader, error)
@@ -158,104 +153,16 @@ func WriteConcurrency(c int) ConvertOption {
 	}
 }
 
-func ReadStreamDescriptorFile(ctx context.Context, bkt objstore.Bucket, extLabelsHash schema.ExternalLabelsHash, l *slog.Logger) (schema.StreamDescriptor, error) {
-	sdfile := schema.StreamDescriptorFileNameForBlock(extLabelsHash)
-	attrs, err := bkt.Attributes(ctx, sdfile)
-	if err != nil {
-		return schema.StreamDescriptor{}, fmt.Errorf("unable to attr %s: %w", sdfile, err)
-	}
-	rdr, err := bkt.Get(ctx, sdfile)
-	if err != nil {
-		return schema.StreamDescriptor{}, fmt.Errorf("unable to get %s: %w", sdfile, err)
-	}
-	defer slogerrcapture.Do(l, rdr.Close, "closing stream descriptor file reader %s", sdfile)
-
-	bp, ok := bufPool.Get().(*[]byte)
-	if !ok {
-		b := make([]byte, 0, attrs.Size)
-		bp = &b
-	}
-	defer bufPool.Put(bp)
-
-	buf := *bp
-	if cap(buf) < int(attrs.Size) {
-		buf = make([]byte, attrs.Size)
-		*bp = buf
-	} else {
-		buf = buf[:attrs.Size]
-	}
-	*bp = buf
-
-	if _, err := io.ReadFull(rdr, buf); err != nil {
-		return schema.StreamDescriptor{}, fmt.Errorf("unable to read %s: %w", sdfile, err)
-	}
-
-	metapb := &streampb.StreamDescriptor{}
-	if err := proto.Unmarshal(buf, metapb); err != nil {
-		return schema.StreamDescriptor{}, fmt.Errorf("unable to read %s: %w", sdfile, err)
-	}
-
-	if len(metapb.GetExternalLabels()) == 0 {
-		return schema.StreamDescriptor{}, fmt.Errorf("stream descriptor %s has no external labels", sdfile)
-	}
-
-	extLbls := schema.ExternalLabels(metapb.GetExternalLabels())
-	if extLbls.Hash() != extLabelsHash {
-		return schema.StreamDescriptor{}, fmt.Errorf("stream descriptor %s has invalid external labels hash: got %d, want %d", sdfile, extLbls.Hash(), extLabelsHash)
-	}
-
-	return schema.StreamDescriptor{
-		ExternalLabels: metapb.GetExternalLabels(),
-	}, nil
-}
-
 func WriteStreamDescriptorFile(
 	ctx context.Context,
-	log *slog.Logger,
 	bkt objstore.Bucket,
 	extLabels schema.ExternalLabels,
-	streamHashMap map[schema.ExternalLabelsHash]schema.ExternalLabels,
 ) error {
-	extLabelHash := extLabels.Hash()
-	filename := schema.StreamDescriptorFileNameForBlock(extLabelHash)
-
-	// Checking for hash collisions:
-	// If a discovered stream has different labels than the new stream with the same hash
-	// we panic. If it has the same labels, we can just return nil as it is already uploaded.
-	//
-	// If a new stream is being written, it won't be in the streamHashMap so we still need to
-	// 1. Check if it exists in the bucket in case another converter uploaded after we called
-	// discoverer.Streams()
-	// 2a. If stream file does not exist, just upload.
-	// 2b. If stream file exists and labels are not equal - panic, otherwise,
-	// proceed with the upload.
-	if foundExtLabels, ok := streamHashMap[extLabelHash]; ok {
-		if !maps.Equal(extLabels, foundExtLabels) {
-			panic("BUG: possible hash collision found while uploading stream file")
-		}
-
-		return nil
-	}
-
-	exists, err := bkt.Exists(ctx, filename)
-	if err != nil {
-		return fmt.Errorf("failed to check if file exists in bucket: %w", err)
-	}
-	if exists {
-		sdfile, err := ReadStreamDescriptorFile(ctx, bkt, extLabelHash, log)
-		if err != nil {
-			return fmt.Errorf("failed to read stream descriptor from bucket: %w", err)
-		}
-		if !maps.Equal(sdfile.ExternalLabels, extLabels) {
-			panic("BUG: possible hash collision found while uploading stream file")
-		}
-	}
-
 	data, err := proto.Marshal(&streampb.StreamDescriptor{ExternalLabels: extLabels})
 	if err != nil {
 		return err
 	}
-	return bkt.Upload(ctx, filename, bytes.NewReader(data))
+	return bkt.Upload(ctx, schema.StreamDescriptorFileNameForBlock(extLabels.Hash()), bytes.NewReader(data))
 }
 
 func ConvertTSDBBlock(
@@ -345,59 +252,6 @@ type blockSeries struct {
 	seriesIdx int // index of the series in the block postings
 	ref       storage.SeriesRef
 	labels    labels.Labels
-}
-
-func ReadMetaFile(ctx context.Context, bkt objstore.Bucket, date util.Date, extLabelsHash schema.ExternalLabelsHash, l *slog.Logger) (schema.Meta, error) {
-	mfile := schema.MetaFileNameForBlock(date, extLabelsHash)
-	attrs, err := bkt.Attributes(ctx, mfile)
-	if err != nil {
-		return schema.Meta{}, fmt.Errorf("unable to attr %s: %w", mfile, err)
-	}
-
-	rdr, err := bkt.Get(ctx, mfile)
-	if err != nil {
-		return schema.Meta{}, fmt.Errorf("unable to get %s: %w", mfile, err)
-	}
-	defer slogerrcapture.Do(l, rdr.Close, "closing meta file reader %s", mfile)
-
-	bp, ok := bufPool.Get().(*[]byte)
-	if !ok {
-		b := make([]byte, 0, attrs.Size)
-		bp = &b
-	}
-	defer bufPool.Put(bp)
-
-	buf := *bp
-	if cap(buf) < int(attrs.Size) {
-		buf = make([]byte, attrs.Size)
-		*bp = buf
-	} else {
-		buf = buf[:attrs.Size]
-	}
-	*bp = buf
-
-	if _, err := io.ReadFull(rdr, buf); err != nil {
-		return schema.Meta{}, fmt.Errorf("unable to read %s: %w", mfile, err)
-	}
-
-	metapb := &metapb.Metadata{}
-	if err := proto.Unmarshal(buf, metapb); err != nil {
-		return schema.Meta{}, fmt.Errorf("unable to read %s: %w", mfile, err)
-	}
-
-	// for version == 0
-	m := make(map[string][]string, len(metapb.GetColumnsForName()))
-	for k, v := range metapb.GetColumnsForName() {
-		m[k] = v.GetColumns()
-	}
-	return schema.Meta{
-		Version:        int(metapb.GetVersion()),
-		Date:           date,
-		Mint:           metapb.GetMint(),
-		Maxt:           metapb.GetMaxt(),
-		Shards:         metapb.GetShards(),
-		ColumnsForName: m,
-	}, nil
 }
 
 func writeMetaFile(ctx context.Context, day util.Date, extLabelsHash schema.ExternalLabelsHash, numShards int64, bkt objstore.Bucket) error {

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -2,7 +2,7 @@
 // Licensed under the Apache 2.0 license found in the LICENSE file or at:
 //     https://opensource.org/licenses/Apache-2.0
 
-package convert_test
+package convert
 
 import (
 	"bytes"
@@ -24,7 +24,6 @@ import (
 	"github.com/thanos-io/objstore/providers/filesystem"
 	"go.uber.org/goleak"
 
-	"github.com/thanos-io/thanos-parquet-gateway/convert"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
 	"github.com/thanos-io/thanos-parquet-gateway/locate"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
@@ -65,13 +64,13 @@ func TestConverter(t *testing.T) {
 	ts := time.UnixMilli(h.MinTime()).UTC()
 	d := util.NewDate(ts.Year(), ts.Month(), ts.Day())
 
-	opts := []convert.ConvertOption{
-		convert.SortBy(labels.MetricName),
-		convert.RowGroupSize(250),
-		convert.RowGroupCount(2),
-		convert.LabelPageBufferSize(units.KiB), // results in 2 pages
+	opts := []ConvertOption{
+		SortBy(labels.MetricName),
+		RowGroupSize(250),
+		RowGroupCount(2),
+		LabelPageBufferSize(units.KiB), // results in 2 pages
 	}
-	if err := convert.ConvertTSDBBlock(t.Context(), bkt, d, schema.ExternalLabelsHash(0), []convert.Convertible{&convert.HeadBlock{Head: h}}, opts...); err != nil {
+	if err := ConvertTSDBBlock(t.Context(), bkt, d, schema.ExternalLabelsHash(0), []Convertible{&HeadBlock{Head: h}}, opts...); err != nil {
 		t.Fatalf("unable to convert tsdb block: %s", err)
 	}
 
@@ -160,11 +159,11 @@ func TestConverterIndexWithManyLabelNames(t *testing.T) {
 	ts := time.UnixMilli(h.MinTime()).UTC()
 	d := util.NewDate(ts.Year(), ts.Month(), ts.Day())
 
-	opts := []convert.ConvertOption{
-		convert.SortBy(labels.MetricName),
-		convert.LabelPageBufferSize(units.KiB), // results in 2 pages
+	opts := []ConvertOption{
+		SortBy(labels.MetricName),
+		LabelPageBufferSize(units.KiB), // results in 2 pages
 	}
-	if err := convert.ConvertTSDBBlock(t.Context(), bkt, d, schema.ExternalLabelsHash(0), []convert.Convertible{&convert.HeadBlock{h}}, opts...); err != nil {
+	if err := ConvertTSDBBlock(t.Context(), bkt, d, schema.ExternalLabelsHash(0), []Convertible{&HeadBlock{h}}, opts...); err != nil {
 		t.Fatalf("unable to convert tsdb block: %s", err)
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -1360,7 +1360,7 @@ func storageToDBWithBkt(tb testing.TB, st *teststorage.TestStorage, bkt objstore
 	day := util.NewDate(ts.Year(), ts.Month(), ts.Day())
 
 	require.NoError(tb, convert.ConvertTSDBBlock(ctx, bkt, day, extLabels.Hash(), []convert.Convertible{&convert.HeadBlock{Head: h}}))
-	require.NoError(tb, convert.WriteStreamDescriptorFile(ctx, nil, bkt, extLabels, map[schema.ExternalLabelsHash]schema.ExternalLabels{}))
+	require.NoError(tb, convert.WriteStreamDescriptorFile(ctx, bkt, extLabels))
 
 	discoverer := locate.NewDiscoverer(bkt)
 	require.NoError(tb, discoverer.Discover(ctx))

--- a/locate/discover.go
+++ b/locate/discover.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"math"
@@ -16,17 +17,21 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/sourcegraph/conc/pool"
 	"github.com/thanos-io/objstore"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
 
-	"github.com/thanos-io/thanos-parquet-gateway/convert"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/slogerrcapture"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
+	"github.com/thanos-io/thanos-parquet-gateway/proto/metapb"
+	"github.com/thanos-io/thanos-parquet-gateway/proto/streampb"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
 )
+
+var bufPool sync.Pool
 
 type discoveryConfig struct {
 	concurrency int
@@ -163,7 +168,7 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 			continue
 		}
 		p.Go(func(ctx context.Context) error {
-			sd, err := convert.ReadStreamDescriptorFile(ctx, s.bkt, discoveredHash, s.l)
+			sd, err := ReadStreamDescriptorFile(ctx, s.bkt, discoveredHash, s.l)
 			if err != nil {
 				return fmt.Errorf("unable to read stream descriptor for hash %q: %w", discoveredHash.String(), err)
 			}
@@ -203,7 +208,7 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 	for discoveredHash := range futureBlocks {
 		for blockDate := range futureBlocks[discoveredHash].filesByDate {
 			p.Go(func(ctx context.Context) error {
-				meta, err := convert.ReadMetaFile(ctx, s.bkt, blockDate, discoveredHash, s.l)
+				meta, err := readMetaFile(ctx, s.bkt, blockDate, discoveredHash, s.l)
 				if err != nil {
 					return fmt.Errorf("unable to read meta file for block date %q hash %q: %w", blockDate, discoveredHash.String(), err)
 				}
@@ -255,6 +260,110 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 	syncLastSuccessfulTime.WithLabelValues(whatDiscoverer).SetToCurrentTime()
 
 	return nil
+}
+
+func ReadStreamDescriptorFile(ctx context.Context, bkt objstore.Bucket, extLabelsHash schema.ExternalLabelsHash, l *slog.Logger) (schema.StreamDescriptor, error) {
+	sdfile := schema.StreamDescriptorFileNameForBlock(extLabelsHash)
+	attrs, err := bkt.Attributes(ctx, sdfile)
+	if err != nil {
+		return schema.StreamDescriptor{}, fmt.Errorf("unable to attr %s: %w", sdfile, err)
+	}
+	rdr, err := bkt.Get(ctx, sdfile)
+	if err != nil {
+		return schema.StreamDescriptor{}, fmt.Errorf("unable to get %s: %w", sdfile, err)
+	}
+	defer slogerrcapture.Do(l, rdr.Close, "closing stream descriptor file reader %s", sdfile)
+
+	bp, ok := bufPool.Get().(*[]byte)
+	if !ok {
+		b := make([]byte, 0, attrs.Size)
+		bp = &b
+	}
+	defer bufPool.Put(bp)
+
+	buf := *bp
+	if cap(buf) < int(attrs.Size) {
+		buf = make([]byte, attrs.Size)
+		*bp = buf
+	} else {
+		buf = buf[:attrs.Size]
+	}
+	*bp = buf
+
+	if _, err := io.ReadFull(rdr, buf); err != nil {
+		return schema.StreamDescriptor{}, fmt.Errorf("unable to read %s: %w", sdfile, err)
+	}
+
+	streampb := &streampb.StreamDescriptor{}
+	if err := proto.Unmarshal(buf, streampb); err != nil {
+		return schema.StreamDescriptor{}, fmt.Errorf("unable to read %s: %w", sdfile, err)
+	}
+
+	if len(streampb.GetExternalLabels()) == 0 {
+		return schema.StreamDescriptor{}, fmt.Errorf("stream descriptor %s has no external labels", sdfile)
+	}
+
+	extLbls := schema.ExternalLabels(streampb.GetExternalLabels())
+	if extLbls.Hash() != extLabelsHash {
+		return schema.StreamDescriptor{}, fmt.Errorf("stream descriptor %s has invalid external labels hash: got %d, want %d", sdfile, extLbls.Hash(), extLabelsHash)
+	}
+
+	return schema.StreamDescriptor{
+		ExternalLabels: streampb.GetExternalLabels(),
+	}, nil
+}
+
+func readMetaFile(ctx context.Context, bkt objstore.Bucket, date util.Date, extLabelsHash schema.ExternalLabelsHash, l *slog.Logger) (schema.Meta, error) {
+	mfile := schema.MetaFileNameForBlock(date, extLabelsHash)
+	attrs, err := bkt.Attributes(ctx, mfile)
+	if err != nil {
+		return schema.Meta{}, fmt.Errorf("unable to attr %s: %w", mfile, err)
+	}
+
+	rdr, err := bkt.Get(ctx, mfile)
+	if err != nil {
+		return schema.Meta{}, fmt.Errorf("unable to get %s: %w", mfile, err)
+	}
+	defer slogerrcapture.Do(l, rdr.Close, "closing meta file reader %s", mfile)
+
+	bp, ok := bufPool.Get().(*[]byte)
+	if !ok {
+		b := make([]byte, 0, attrs.Size)
+		bp = &b
+	}
+	defer bufPool.Put(bp)
+
+	buf := *bp
+	if cap(buf) < int(attrs.Size) {
+		buf = make([]byte, attrs.Size)
+		*bp = buf
+	} else {
+		buf = buf[:attrs.Size]
+	}
+	*bp = buf
+
+	if _, err := io.ReadFull(rdr, buf); err != nil {
+		return schema.Meta{}, fmt.Errorf("unable to read %s: %w", mfile, err)
+	}
+
+	metapb := &metapb.Metadata{}
+	if err := proto.Unmarshal(buf, metapb); err != nil {
+		return schema.Meta{}, fmt.Errorf("unable to read %s: %w", mfile, err)
+	}
+
+	// for version == 0
+	m := make(map[string][]string, len(metapb.GetColumnsForName()))
+	for k, v := range metapb.GetColumnsForName() {
+		m[k] = v.GetColumns()
+	}
+	return schema.Meta{
+		Version:        int(metapb.GetVersion()),
+		Date:           date,
+		Mint:           metapb.GetMint(),
+		Maxt:           metapb.GetMaxt(),
+		Shards:         metapb.GetShards(),
+		ColumnsForName: m,
+	}, nil
 }
 
 type tsdbDiscoveryConfig struct {


### PR DESCRIPTION
Implement simple hash collision checking when uploading `stream.pb`:

If a discovered stream has different labels than the new stream with the same hash
we panic. If it has the same labels, we can just return nil as it is already uploaded.

If a new stream is being written, it won't be in the streamHashMap so we still need to
* Check if it exists in the bucket in case another converter uploaded after we called
discoverer.Streams()
	* If stream file does not exist, just upload.
	* If stream file exists and labels are not equal - panic, otherwise,
proceed with the upload.
