### PR TITLE
convert: optimize a little bit

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -389,11 +389,7 @@ func shardedIndexRowReader(
 
 			concurrency: opts.encodingConcurrency,
 
-			chunksColumn0:    columnIDForKnownColumn(s, schema.ChunksColumn0),
-			chunksColumn1:    columnIDForKnownColumn(s, schema.ChunksColumn1),
-			chunksColumn2:    columnIDForKnownColumn(s, schema.ChunksColumn2),
-			labelIndexColumn: columnIDForKnownColumn(s, schema.LabelIndexColumn),
-			labelHashColumn:  columnIDForKnownColumn(s, schema.LabelHashColumn),
+			columnCache: make(map[string]int),
 		}
 	}
 	return shardIndexRowReader, nil
@@ -554,7 +550,6 @@ func newConverter(
 	chunkBufferPool parquet.BufferPool,
 	labelPageBufferSize int,
 	chunkPageBufferSize int,
-
 ) *converter {
 	return &converter{
 		date:          date,
@@ -679,7 +674,6 @@ func newSplitFileWriter(ctx context.Context, bkt objstore.Bucket, inSchema *parq
 		fileWriters: fileWriters,
 		g:           g,
 	}, nil
-
 }
 
 func (s *splitPipeFileWriter) WriteRows(rows []parquet.Row) (int, error) {

--- a/convert/tsdb.go
+++ b/convert/tsdb.go
@@ -30,18 +30,19 @@ type indexRowReader struct {
 
 	concurrency int
 
-	chunksColumn0    int
-	chunksColumn1    int
-	chunksColumn2    int
-	labelIndexColumn int
-	labelHashColumn  int
+	columnCache map[string]int
 }
 
 var _ parquet.RowReader = &indexRowReader{}
 
-func columnIDForKnownColumn(schema *parquet.Schema, columnName string) int {
-	lc, _ := schema.Lookup(columnName)
-	return lc.ColumnIndex
+func (rr *indexRowReader) lookupColumnID(columnName string) int {
+	colID, ok := rr.columnCache[columnName]
+	if ok {
+		return colID
+	}
+	lc, _ := rr.schema.Lookup(columnName)
+	rr.columnCache[columnName] = lc.ColumnIndex
+	return rr.columnCache[columnName]
 }
 
 func (rr *indexRowReader) Close() error {
@@ -114,13 +115,13 @@ func (rr *indexRowReader) ReadRows(buf []parquet.Row) (int, error) {
 
 		chkLbls.Range(func(l labels.Label) {
 			colName := schema.LabelNameToColumn(l.Name)
-			lc, _ := rr.schema.Lookup(colName)
-			rr.rowBuilder.Add(lc.ColumnIndex, parquet.ValueOf(l.Value))
+			colIdx := rr.lookupColumnID(colName)
+			rr.rowBuilder.Add(colIdx, parquet.ValueOf(l.Value))
 			// we need to address for projecting chunk columns away later so we need to correct for the offset here
-			colIdxSlice = append(colIdxSlice, lc.ColumnIndex-schema.ChunkColumnsPerDay-1)
+			colIdxSlice = append(colIdxSlice, colIdx-schema.ChunkColumnsPerDay-1)
 		})
-		rr.rowBuilder.Add(rr.labelIndexColumn, parquet.ValueOf(encoding.EncodeLabelColumnIndex(colIdxSlice)))
-		rr.rowBuilder.Add(rr.labelHashColumn, parquet.ValueOf(chkLbls.Hash()))
+		rr.rowBuilder.Add(rr.lookupColumnID(schema.LabelIndexColumn), parquet.ValueOf(encoding.EncodeLabelColumnIndex(colIdxSlice)))
+		rr.rowBuilder.Add(rr.lookupColumnID(schema.LabelHashColumn), parquet.ValueOf(chkLbls.Hash()))
 
 		if allChunksEmpty(chkBytes) {
 			continue
@@ -131,11 +132,11 @@ func (rr *indexRowReader) ReadRows(buf []parquet.Row) (int, error) {
 			}
 			switch idx {
 			case 0:
-				rr.rowBuilder.Add(rr.chunksColumn0, parquet.ValueOf(chk))
+				rr.rowBuilder.Add(rr.lookupColumnID(schema.ChunksColumn0), parquet.ValueOf(chk))
 			case 1:
-				rr.rowBuilder.Add(rr.chunksColumn1, parquet.ValueOf(chk))
+				rr.rowBuilder.Add(rr.lookupColumnID(schema.ChunksColumn1), parquet.ValueOf(chk))
 			case 2:
-				rr.rowBuilder.Add(rr.chunksColumn2, parquet.ValueOf(chk))
+				rr.rowBuilder.Add(rr.lookupColumnID(schema.ChunksColumn2), parquet.ValueOf(chk))
 			}
 		}
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -98,18 +98,17 @@ func BuildSchemaFromLabels(lbls []string) *parquet.Schema {
 
 func WithCompression(s *parquet.Schema) *parquet.Schema {
 	g := make(parquet.Group)
+	cdc := &zstd.Codec{Level: zstd.SpeedBetterCompression, Concurrency: 4}
 
 	for _, c := range s.Columns() {
 		lc, _ := s.Lookup(c...)
-		g[lc.Path[0]] = parquet.Compressed(lc.Node, &zstd.Codec{Level: zstd.SpeedBetterCompression, Concurrency: 4})
+		g[lc.Path[0]] = parquet.Compressed(lc.Node, cdc)
 	}
 
 	return parquet.NewSchema("compressed", g)
 }
 
-var (
-	ChunkColumns = []string{LabelHashColumn, ChunksColumn0, ChunksColumn1, ChunksColumn2}
-)
+var ChunkColumns = []string{LabelHashColumn, ChunksColumn0, ChunksColumn1, ChunksColumn2}
 
 func ChunkProjection(s *parquet.Schema) *parquet.Schema {
 	g := make(parquet.Group)


### PR DESCRIPTION
- Cache column lookups to reduce allocs
- Reuse the same codec to reduce memory allocations

Diff:

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos-parquet-gateway/convert
cpu: Intel(R) Core(TM) Ultra 7 165H
             │     old      │               newv1                │
             │    sec/op    │   sec/op     vs base               │
Converter-22   467.6m ± 11%   424.8m ± 3%  -9.17% (p=0.000 n=10)

             │     old      │                newv1                 │
             │     B/op     │     B/op      vs base                │
Converter-22   760.9Mi ± 1%   651.2Mi ± 2%  -14.42% (p=0.000 n=10)

             │     old     │               newv1                │
             │  allocs/op  │  allocs/op   vs base               │
Converter-22   4.050M ± 0%   3.807M ± 0%  -5.99% (p=0.000 n=10)
```