### PR TITLE
convert: optimize iterators reuse

### DIFF
--- a/convert/chunks.go
+++ b/convert/chunks.go
@@ -16,17 +16,15 @@ import (
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
 )
 
-func collectChunks(it chunks.Iterator) ([schema.ChunkColumnsPerDay][]byte, error) {
-	var (
-		res [schema.ChunkColumnsPerDay][]byte
-	)
+func collectChunks(it chunks.Iterator) ([schema.ChunkColumnsPerDay][]byte, chunks.Iterator, error) {
+	var res [schema.ChunkColumnsPerDay][]byte
 	// NOTE: 'it' should hold chunks for one day. Chunks are usually length 2h so we should get 12 of them.
 	chunks := make([]chunks.Meta, 0, 12)
 	for it.Next() {
 		chunks = append(chunks, it.At())
 	}
 	if err := it.Err(); err != nil {
-		return res, fmt.Errorf("unable to iterate chunks: %w", err)
+		return res, it, fmt.Errorf("unable to iterate chunks: %w", err)
 	}
 	// NOTE: we need to sort chunks here as they come from different blocks that we merged.
 	// Prometheus does not guarantee that they are sorted. We have to sort them either here or
@@ -49,5 +47,5 @@ func collectChunks(it chunks.Iterator) ([schema.ChunkColumnsPerDay][]byte, error
 		chkBytes = append(chkBytes, bs...)
 		res[chkIdx] = chkBytes
 	}
-	return res, nil
+	return res, it, nil
 }

--- a/convert/tsdb.go
+++ b/convert/tsdb.go
@@ -13,6 +13,7 @@ import (
 	"github.com/parquet-go/parquet-go"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/tsdb/chunks"
 
 	"github.com/thanos-io/thanos-parquet-gateway/internal/encoding"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
@@ -77,11 +78,17 @@ func (rr *indexRowReader) ReadRows(buf []parquet.Row) (int, error) {
 
 	chunkSeriesC := make(chan chunkSeriesPromise, rr.concurrency)
 
+	iterPool := make(chan chunks.Iterator, rr.concurrency)
+	for range rr.concurrency {
+		iterPool <- nil
+	}
+
 	go func() {
 		defer close(chunkSeriesC)
+
 		for j := 0; j < len(buf) && rr.seriesSet.Next(); j++ {
 			s := rr.seriesSet.At()
-			it := s.Iterator(nil)
+			it := s.Iterator(<-iterPool)
 
 			promise := chunkSeriesPromise{
 				s: s,
@@ -91,7 +98,8 @@ func (rr *indexRowReader) ReadRows(buf []parquet.Row) (int, error) {
 			chunkSeriesC <- promise
 
 			go func() {
-				chkBytes, err := collectChunks(it)
+				chkBytes, it, err := collectChunks(it)
+				iterPool <- it
 				promise.c <- chkBytesOrError{chkBytes: chkBytes, err: err}
 				close(promise.c)
 			}()


### PR DESCRIPTION
Reuse iterators to use less memory. Diff:

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos-parquet-gateway/convert
cpu: Intel(R) Core(TM) Ultra 7 165H
             │     old     │             newv1             │
             │   sec/op    │   sec/op     vs base          │
Converter-22   436.8m ± 6%   427.9m ± 5%  ~ (p=0.853 n=10)

             │     old      │                newv1                │
             │     B/op     │     B/op      vs base               │
Converter-22   646.1Mi ± 3%   624.5Mi ± 2%  -3.33% (p=0.000 n=10)

             │     old     │               newv1                │
             │  allocs/op  │  allocs/op   vs base               │
Converter-22   3.809M ± 0%   3.571M ± 0%  -6.24% (p=0.000 n=10)
```

In general, I don't like this function much so I will refactor it a little bit in the future.