### PR TITLE
convert: pool chunks buffer

### DIFF
--- a/convert/chunks.go
+++ b/convert/chunks.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/prometheus/prometheus/tsdb/chunks"
@@ -16,10 +17,22 @@ import (
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
 )
 
+var chunksPool = sync.Pool{
+	New: func() any {
+		s := make([]chunks.Meta, 0, 12)
+		return &s
+	},
+}
+
 func collectChunks(it chunks.Iterator) ([schema.ChunkColumnsPerDay][]byte, chunks.Iterator, error) {
 	var res [schema.ChunkColumnsPerDay][]byte
 	// NOTE: 'it' should hold chunks for one day. Chunks are usually length 2h so we should get 12 of them.
-	chunks := make([]chunks.Meta, 0, 12)
+	chunksBuf := chunksPool.Get().(*[]chunks.Meta)
+	chunks := (*chunksBuf)[:0]
+	defer func() {
+		*chunksBuf = chunks
+		chunksPool.Put(chunksBuf)
+	}()
 	for it.Next() {
 		chunks = append(chunks, it.At())
 	}


### PR DESCRIPTION
Another small optimization.

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos-parquet-gateway/convert
cpu: Intel(R) Core(TM) Ultra 7 165H
             │     old     │             newv3             │
             │   sec/op    │   sec/op     vs base          │
Converter-22   433.6m ± 4%   440.0m ± 5%  ~ (p=0.912 n=10)

             │     old      │                newv3                │
             │     B/op     │     B/op      vs base               │
Converter-22   626.7Mi ± 2%   587.1Mi ± 4%  -6.32% (p=0.000 n=10)

             │     old     │               newv3                │
             │  allocs/op  │  allocs/op   vs base               │
Converter-22   3.571M ± 0%   3.492M ± 0%  -2.21% (p=0.000 n=10)
```