### PR TITLE
*: convert optimizations

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -688,8 +688,8 @@ func newSplitFileWriter(ctx context.Context, bkt objstore.Bucket, inSchema *parq
 		}
 
 		r, w := io.Pipe()
-		bw := bufio.NewWriterSize(w, 32_000_000)
-		br := bufio.NewReaderSize(r, 32_000_000)
+		bw := bufio.NewWriterSize(w, 1024)
+		br := bufio.NewReaderSize(r, 1024)
 		fileWriters[file] = &fileWriter{
 			pw:   parquet.NewGenericWriter[any](bw, append(cfg.opts, cfg.s)...),
 			w:    w,

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -96,13 +96,14 @@ func BuildSchemaFromLabels(lbls []string) *parquet.Schema {
 	return parquet.NewSchema("tsdb", g)
 }
 
+var defaultZstdCodec = &zstd.Codec{Level: zstd.SpeedBetterCompression, Concurrency: 1}
+
 func WithCompression(s *parquet.Schema) *parquet.Schema {
 	g := make(parquet.Group)
-	cdc := &zstd.Codec{Level: zstd.SpeedBetterCompression, Concurrency: 4}
 
 	for _, c := range s.Columns() {
 		lc, _ := s.Lookup(c...)
-		g[lc.Path[0]] = parquet.Compressed(lc.Node, cdc)
+		g[lc.Path[0]] = parquet.Compressed(lc.Node, defaultZstdCodec)
 	}
 
 	return parquet.NewSchema("compressed", g)


### PR DESCRIPTION
Reuse zstd codec, reduce bufio sizes. I don't think the big sizes bring any benefit. We also don't make use of the concurrency on the codec level so no need for that (and the big buffers it brings).

Benchmark diff:

```
goos: linux
goarch: amd64
pkg: github.com/thanos-io/thanos-parquet-gateway/convert
cpu: Intel(R) Core(TM) Ultra 7 165H
             │     old     │             new              │
             │   sec/op    │   sec/op     vs base         │
Converter-22   1.164 ± ∞ ¹   1.222 ± ∞ ¹  ~ (p=0.690 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

             │      old      │                 new                  │
             │     B/op      │     B/op       vs base               │
Converter-22   577.5Mi ± ∞ ¹   275.6Mi ± ∞ ¹  -52.27% (p=0.008 n=5)
¹ need >= 6 samples for confidence interval at level 0.95

             │     old      │              new              │
             │  allocs/op   │  allocs/op    vs base         │
Converter-22   3.486M ± ∞ ¹   3.480M ± ∞ ¹  ~ (p=0.151 n=5)
¹ need >= 6 samples for confidence interval at level 0.95
```