### PR TITLE
convert: write real min/max timestamps into meta

### DIFF
--- a/convert/convert.go
+++ b/convert/convert.go
@@ -175,6 +175,18 @@ func WriteStreamDescriptorFile(
 	return bkt.Upload(ctx, schema.StreamDescriptorFileNameForBlock(extLabels.Hash()), bytes.NewReader(data))
 }
 
+func minMaxTimestamp(blks []Convertible) (int64, int64) {
+	mn := int64(math.MaxInt64)
+	mx := int64(math.MinInt64)
+
+	for _, blk := range blks {
+		meta := blk.Meta()
+		mn = min(meta.MinTime, mn)
+		mx = max(meta.MaxTime, mx)
+	}
+	return mn, mx
+}
+
 func ConvertTSDBBlock(
 	ctx context.Context,
 	bkt objstore.Bucket,
@@ -241,7 +253,8 @@ func ConvertTSDBBlock(
 		return fmt.Errorf("failed to convert shards in parallel: %w", err)
 	}
 
-	if err := writeMetaFile(ctx, day, extLabelsHash, int64(len(shardedRowReaders)), bkt, blks); err != nil {
+	mn, mx := minMaxTimestamp(blks)
+	if err := writeMetaFile(ctx, mn, mx, day, extLabelsHash, int64(len(shardedRowReaders)), bkt, blks); err != nil {
 		return fmt.Errorf("failed to write meta file: %w", err)
 	}
 
@@ -265,6 +278,7 @@ type blockSeries struct {
 
 func writeMetaFile(
 	ctx context.Context,
+	mint, maxt int64,
 	day util.Date,
 	extLabelsHash schema.ExternalLabelsHash,
 	numShards int64,
@@ -277,8 +291,8 @@ func writeMetaFile(
 	}
 	meta := &metapb.Metadata{
 		Version:            schema.V2,
-		Mint:               day.MinT(),
-		Maxt:               day.MaxT(),
+		Mint:               mint,
+		Maxt:               maxt,
 		Shards:             numShards,
 		ConvertedFromBLIDs: convertedFromIDs,
 	}

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -69,14 +69,8 @@ func ColumnToLabelName(col string) string {
 	return strings.TrimPrefix(col, LabelColumnPrefix)
 }
 
-func ChunkColumnIndex(m Meta, t time.Time) (int, bool) {
-	mints := time.UnixMilli(m.Mint)
-
-	colIdx := 0
-	for cur := mints.Add(ChunkColumnLength); !t.Before(cur); cur = cur.Add(ChunkColumnLength) {
-		colIdx++
-	}
-	return min(colIdx, ChunkColumnsPerDay-1), true
+func ChunkColumnIndex(t time.Time) int {
+	return (t.UTC().Hour() / int(ChunkColumnLength.Hours())) % ChunkColumnsPerDay
 }
 
 func BuildSchemaFromLabels(lbls []string) *parquet.Schema {

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestDataColumnIndex(t *testing.T) {
-	m := Meta{Mint: 0}
 	for _, tt := range []struct {
 		d      time.Duration
 		expect int
@@ -19,10 +18,10 @@ func TestDataColumnIndex(t *testing.T) {
 		{d: 8 * time.Hour, expect: 1},
 		{d: 11 * time.Hour, expect: 1},
 		{d: 18 * time.Hour, expect: 2},
-		{d: 24 * time.Hour, expect: 2},
+		{d: 24 * time.Hour, expect: 0},
 	} {
 		t.Run("", func(ttt *testing.T) {
-			if got, _ := ChunkColumnIndex(m, time.UnixMilli(m.Mint).Add(tt.d)); got != tt.expect {
+			if got := ChunkColumnIndex(time.UnixMilli(0).Add(tt.d)); got != tt.expect {
 				ttt.Fatalf("unexpected chunk column index %d, expected %d", got, tt.expect)
 			}
 		})

--- a/search/materialize.go
+++ b/search/materialize.go
@@ -7,13 +7,11 @@ package search
 import (
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"iter"
 	"maps"
 	"math"
-
 	"slices"
 	"sync"
 	"time"
@@ -316,14 +314,8 @@ func materializeChunks(
 ) ([][]chunks.Meta, error) {
 	rowCount := totalRows(rr)
 
-	minChunkCol, ok := schema.ChunkColumnIndex(m.Meta, time.UnixMilli(mint))
-	if !ok {
-		return nil, errors.New("unable to find min chunk column")
-	}
-	maxChunkCol, ok := schema.ChunkColumnIndex(m.Meta, time.UnixMilli(maxt))
-	if !ok {
-		return nil, errors.New("unable to find max chunk column")
-	}
+	minChunkCol := schema.ChunkColumnIndex(time.UnixMilli(mint))
+	maxChunkCol := schema.ChunkColumnIndex(time.UnixMilli(maxt))
 	rg := m.ChunkPfile.RowGroups()[rgi]
 
 	numCols := maxChunkCol - minChunkCol + 1
@@ -489,7 +481,6 @@ func materializeLabelNamesV0(ctx context.Context, meta LabelNamesReadMeta, rgi i
 		res = append(res, schema.ColumnToLabelName(cols[k][0]))
 	}
 	return res, annos, nil
-
 }
 
 func materializeLabelNamesV1(ctx context.Context, meta LabelNamesReadMeta, rgi int, rr []rowRange) ([]string, annotations.Annotations, error) {


### PR DESCRIPTION
Write the real min/max timestamps of inputs into the meta file. This permits proper migration of blocks to Parquet because otherwise the min/max timestamps are "lost" if they are not (and most likely they are not) ideally matching the blocks on the TSDB side, and then gaps appear because the old blocks with "more" information according to meta files are not loaded anymore.