### PR TITLE
locate: do not overwrite blocks

### DIFF
--- a/locate/syncer.go
+++ b/locate/syncer.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -189,10 +190,7 @@ func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLab
 	}
 
 	for stream := range s.blocks {
-		if _, ok := blocks[stream]; !ok {
-			continue
-		}
-		s.blocks[stream] = blocks[stream]
+		maps.Copy(s.blocks[stream], blocks[stream])
 	}
 	for _, v := range s.blocks {
 		numBlocks += len(v)


### PR DESCRIPTION
If we override these blocks then the syncer each loop will call mmap again thus leaking fds/maps.