### PR TITLE
Propagate logger and metric registry into promql engine

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -10,7 +10,10 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"go.uber.org/goleak"
 )
 
@@ -147,4 +150,42 @@ config:
 			})
 		}
 	})
+}
+
+func TestEngineFromQueryOptsRegistersMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	eng := engineFromQueryOpts(queryOpts{
+		engineTimeout:   5 * time.Minute,
+		defaultLookback: 5 * time.Minute,
+	}, logger, reg)
+	if eng == nil {
+		t.Fatal("engine is nil")
+	}
+
+	families, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gathering metrics: %v", err)
+	}
+
+	want := map[string]dto.MetricType{
+		"thanos_engine_queries":       dto.MetricType_GAUGE,
+		"thanos_engine_queries_total": dto.MetricType_COUNTER,
+	}
+
+	found := make(map[string]bool, len(want))
+	for _, fam := range families {
+		if expectedType, ok := want[fam.GetName()]; ok {
+			if fam.GetType() != expectedType {
+				t.Errorf("metric %s: expected type %s, got %s", fam.GetName(), expectedType, fam.GetType())
+			}
+			found[fam.GetName()] = true
+		}
+	}
+	for name := range want {
+		if !found[name] {
+			t.Errorf("expected metric %s not found in registry", name)
+		}
+	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -169,8 +169,8 @@ func registerServeApp(app *kingpin.Application) (*kingpin.CmdClause, func(contex
 			cfdb.ExternalLabels(labels.FromMap(opts.query.externalLabels)),
 		)
 
-		setupPromAPI(&g, log, db, opts.promAPI, opts.query)
-		setupThanosAPI(&g, log, db, opts.thanosAPI, opts.query)
+		setupPromAPI(&g, log, db, reg, opts.promAPI, opts.query)
+		setupThanosAPI(&g, log, db, reg, opts.thanosAPI, opts.query)
 		setupInternalAPI(&g, log, reg, opts.internalAPI)
 
 		return g.Run()
@@ -198,7 +198,7 @@ type queryOpts struct {
 	selectChunkPartitionMaxConcurrency int
 }
 
-func engineFromQueryOpts(opts queryOpts) promql.QueryEngine {
+func engineFromQueryOpts(opts queryOpts, logger *slog.Logger, reg prometheus.Registerer) promql.QueryEngine {
 	return engine.New(engine.Opts{
 		DisableDuplicateLabelChecks: true,
 		LogicalOptimizers: []logicalplan.Optimizer{
@@ -206,8 +206,8 @@ func engineFromQueryOpts(opts queryOpts) promql.QueryEngine {
 		},
 
 		EngineOpts: promql.EngineOpts{
-			Logger:                   nil,
-			Reg:                      nil,
+			Logger:                   logger,
+			Reg:                      reg,
 			MaxSamples:               10_000_000,
 			Timeout:                  opts.engineTimeout,
 			NoStepSubqueryIntervalFn: func(int64) int64 { return time.Minute.Milliseconds() },
@@ -218,10 +218,9 @@ func engineFromQueryOpts(opts queryOpts) promql.QueryEngine {
 			EnableDelayedNameRemoval: false,
 		},
 	})
-
 }
 
-func setupThanosAPI(g *run.Group, log *slog.Logger, db *cfdb.DB, opts apiOpts, qOpts queryOpts) {
+func setupThanosAPI(g *run.Group, log *slog.Logger, db *cfdb.DB, reg prometheus.Registerer, opts apiOpts, qOpts queryOpts) {
 	server := grpc.NewServer(
 		grpc.MaxSendMsgSize(math.MaxInt32),
 		grpc.MaxRecvMsgSize(math.MaxInt32),
@@ -234,7 +233,7 @@ func setupThanosAPI(g *run.Group, log *slog.Logger, db *cfdb.DB, opts apiOpts, q
 
 	queryServer := cfgrpc.NewQueryServer(
 		db,
-		engineFromQueryOpts(qOpts),
+		engineFromQueryOpts(qOpts, log, reg),
 		cfgrpc.ConcurrentQueryQuota(qOpts.concurrentQueryQuota),
 		cfgrpc.SelectChunkBytesQuota(qOpts.selectChunkBytesQuota),
 		cfgrpc.SelectRowCountQuota(qOpts.selectRowCountQuota),
@@ -284,8 +283,8 @@ func setupThanosAPI(g *run.Group, log *slog.Logger, db *cfdb.DB, opts apiOpts, q
 	})
 }
 
-func setupPromAPI(g *run.Group, log *slog.Logger, db *cfdb.DB, opts apiOpts, qOpts queryOpts) {
-	handler := cfhttp.NewAPI(db, engineFromQueryOpts(qOpts),
+func setupPromAPI(g *run.Group, log *slog.Logger, db *cfdb.DB, reg prometheus.Registerer, opts apiOpts, qOpts queryOpts) {
+	handler := cfhttp.NewAPI(db, engineFromQueryOpts(qOpts, log, reg),
 		cfhttp.QueryOptions(
 			cfhttp.DefaultStep(qOpts.defaultStep),
 			cfhttp.DefaultLookback(qOpts.defaultLookback),


### PR DESCRIPTION
The Thanos PromQL engine was being initialized without any logger or any metric registry so it wasn't able to expose metrics about its own execution into the parquet gateway or correctly log with severity filtering.

Fix by passing the parquet-gateway's logger and metric registry to the engine.

A test is added to validate the metric integration.