### PR TITLE
Parquet gateway tracing configuration update and trace span enhancements

### DIFF
--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -277,7 +277,7 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			return err
 		}
 	}
-	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
+	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
 	switch results := res.Value.(type) {
 	case promql.Vector:
 		for _, result := range results {
@@ -299,7 +299,9 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 	}
 	span.SetAttributes(
 		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.samples", sampleCount),
+		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
+		attribute.Int64("result.float_samples", floatSampleCount),
+		attribute.Int64("result.histogram_samples", histogramSampleCount),
 	)
 	if stats := qry.Stats(); stats != nil {
 		if err := srv.Send(querypb.NewQueryStatsResponse(toQueryStats(stats))); err != nil {
@@ -351,8 +353,7 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			return err
 		}
 	}
-	// TODO native histogram stats in traces, with separate counts for float samples, histogram samples and total
-	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
+	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
 	switch results := res.Value.(type) {
 	case promql.Matrix:
 		for _, result := range results {
@@ -386,7 +387,9 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 	}
 	span.SetAttributes(
 		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.samples", sampleCount),
+		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
+		attribute.Int64("result.float_samples", floatSampleCount),
+		attribute.Int64("result.histogram_samples", histogramSampleCount),
 	)
 
 	if stats := qry.Stats(); stats != nil {

--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -407,6 +407,8 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 }
 
 func (qs *QueryServer) Series(request *storepb.SeriesRequest, srv storepb.Store_SeriesServer) (rerr error) {
+	span := tracing.SpanFromContext(srv.Context())
+
 	qryable := qs.queryable(request.WithoutReplicaLabels...)
 
 	ms, err := storepb.MatchersToPromMatchers(request.Matchers...)
@@ -435,20 +437,20 @@ func (qs *QueryServer) Series(request *storepb.SeriesRequest, srv storepb.Store_
 	css := cq.Select(srv.Context(), true, hints, ms...)
 
 	var (
-		i  = int64(0)
-		it chunks.Iterator
+		seriesCount = int64(0)
+		sampleCount = int64(0)
+		it          chunks.Iterator
 	)
 	for css.Next() {
-		i++
-
 		series := css.At()
 
-		if request.Limit > 0 && i > request.Limit {
+		if request.Limit > 0 && seriesCount >= request.Limit {
 			if err := srv.Send(storepb.NewWarnSeriesResponse(warnings.ErrorTruncatedResponse)); err != nil {
 				return status.Error(codes.Aborted, err.Error())
 			}
 			break
 		}
+		seriesCount++
 
 		storeSeries := storepb.Series{Labels: zLabelsFromMetric(series.Labels())}
 
@@ -466,6 +468,7 @@ func (qs *QueryServer) Series(request *storepb.SeriesRequest, srv storepb.Store_
 					Data: chk.Chunk.Bytes(),
 				},
 			})
+			sampleCount += int64(chk.Chunk.NumSamples())
 		}
 		if err := it.Err(); err != nil {
 			return status.Error(codes.Internal, err.Error())
@@ -487,6 +490,11 @@ func (qs *QueryServer) Series(request *storepb.SeriesRequest, srv storepb.Store_
 			return status.Error(codes.Aborted, err.Error())
 		}
 	}
+
+	span.SetAttributes(
+		attribute.Int64("result.series", seriesCount),
+		attribute.Int64("result.samples", sampleCount),
+	)
 
 	return nil
 }

--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -35,6 +35,7 @@ import (
 	"github.com/thanos-io/thanos-parquet-gateway/internal/limits"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/matchers"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
+	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/warnings"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
 )
@@ -276,13 +277,11 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			return err
 		}
 	}
-	var seriesCount, sampleCount int64
+	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
 	switch results := res.Value.(type) {
 	case promql.Vector:
-		seriesCount = int64(len(results))
 		for _, result := range results {
 			samples, histograms := prompb.SamplesFromPromqlSamples(result)
-			sampleCount += int64(len(samples)) + int64(len(histograms))
 			series := &prompb.TimeSeries{
 				Samples:    samples,
 				Histograms: histograms,
@@ -293,8 +292,6 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			}
 		}
 	case promql.Scalar:
-		seriesCount = 1
-		sampleCount = 1
 		series := &prompb.TimeSeries{Samples: []prompb.Sample{{Value: float64(results.V), Timestamp: int64(results.T)}}}
 		if err := srv.Send(querypb.NewQueryResponse(series)); err != nil {
 			return err
@@ -355,13 +352,11 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 		}
 	}
 	// TODO native histogram stats in traces, with separate counts for float samples, histogram samples and total
-	var seriesCount, sampleCount int64
+	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
 	switch results := res.Value.(type) {
 	case promql.Matrix:
-		seriesCount = int64(len(results))
 		for _, result := range results {
 			samples, histograms := prompb.SamplesFromPromqlSeries(result)
-			sampleCount += int64(len(result.Floats)) + int64(len(result.Histograms))
 			series := &prompb.TimeSeries{
 				Samples:    samples,
 				Histograms: histograms,
@@ -372,10 +367,8 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			}
 		}
 	case promql.Vector:
-		seriesCount = int64(len(results))
 		for _, result := range results {
 			samples, histograms := prompb.SamplesFromPromqlSamples(result)
-			sampleCount += int64(len(samples)) + int64(len(histograms))
 			series := &prompb.TimeSeries{
 				Samples:    samples,
 				Histograms: histograms,
@@ -386,8 +379,6 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			}
 		}
 	case promql.Scalar:
-		seriesCount = 1
-		sampleCount = 1
 		series := &prompb.TimeSeries{Samples: []prompb.Sample{{Value: float64(results.V), Timestamp: int64(results.T)}}}
 		if err := srv.Send(querypb.NewQueryRangeResponse(series)); err != nil {
 			return err

--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/thanos-io/thanos-parquet-gateway/db"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/limits"
+	"github.com/thanos-io/thanos-parquet-gateway/internal/matchers"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/warnings"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
@@ -415,6 +416,8 @@ func (qs *QueryServer) Series(request *storepb.SeriesRequest, srv storepb.Store_
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
+
+	span.SetAttributes(attribute.StringSlice("series.matchers", matchers.ToStringSlice(ms)))
 
 	hints := &storage.SelectHints{
 		Start: request.MinTime,

--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -277,7 +277,7 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			return err
 		}
 	}
-	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
+	util.InjectResultMetrics(span, res.Value)
 	switch results := res.Value.(type) {
 	case promql.Vector:
 		for _, result := range results {
@@ -297,12 +297,6 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			return err
 		}
 	}
-	span.SetAttributes(
-		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
-		attribute.Int64("result.float_samples", floatSampleCount),
-		attribute.Int64("result.histogram_samples", histogramSampleCount),
-	)
 	if stats := qry.Stats(); stats != nil {
 		if err := srv.Send(querypb.NewQueryStatsResponse(toQueryStats(stats))); err != nil {
 			return err
@@ -353,7 +347,7 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			return err
 		}
 	}
-	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
+	util.InjectResultMetrics(span, res.Value)
 	switch results := res.Value.(type) {
 	case promql.Matrix:
 		for _, result := range results {
@@ -385,13 +379,6 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			return err
 		}
 	}
-	span.SetAttributes(
-		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
-		attribute.Int64("result.float_samples", floatSampleCount),
-		attribute.Int64("result.histogram_samples", histogramSampleCount),
-	)
-
 	if stats := qry.Stats(); stats != nil {
 		if err := srv.Send(querypb.NewQueryRangeStatsResponse(toQueryStats(stats))); err != nil {
 			return err

--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -275,10 +275,13 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			return err
 		}
 	}
+	var seriesCount, sampleCount int64
 	switch results := res.Value.(type) {
 	case promql.Vector:
+		seriesCount = int64(len(results))
 		for _, result := range results {
 			samples, histograms := prompb.SamplesFromPromqlSamples(result)
+			sampleCount += int64(len(samples)) + int64(len(histograms))
 			series := &prompb.TimeSeries{
 				Samples:    samples,
 				Histograms: histograms,
@@ -289,11 +292,17 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 			}
 		}
 	case promql.Scalar:
+		seriesCount = 1
+		sampleCount = 1
 		series := &prompb.TimeSeries{Samples: []prompb.Sample{{Value: float64(results.V), Timestamp: int64(results.T)}}}
 		if err := srv.Send(querypb.NewQueryResponse(series)); err != nil {
 			return err
 		}
 	}
+	span.SetAttributes(
+		attribute.Int64("result.series", seriesCount),
+		attribute.Int64("result.samples", sampleCount),
+	)
 	if stats := qry.Stats(); stats != nil {
 		if err := srv.Send(querypb.NewQueryStatsResponse(toQueryStats(stats))); err != nil {
 			return err
@@ -344,10 +353,14 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			return err
 		}
 	}
+	// TODO native histogram stats in traces, with separate counts for float samples, histogram samples and total
+	var seriesCount, sampleCount int64
 	switch results := res.Value.(type) {
 	case promql.Matrix:
+		seriesCount = int64(len(results))
 		for _, result := range results {
 			samples, histograms := prompb.SamplesFromPromqlSeries(result)
+			sampleCount += int64(len(result.Floats)) + int64(len(result.Histograms))
 			series := &prompb.TimeSeries{
 				Samples:    samples,
 				Histograms: histograms,
@@ -358,8 +371,10 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			}
 		}
 	case promql.Vector:
+		seriesCount = int64(len(results))
 		for _, result := range results {
 			samples, histograms := prompb.SamplesFromPromqlSamples(result)
+			sampleCount += int64(len(samples)) + int64(len(histograms))
 			series := &prompb.TimeSeries{
 				Samples:    samples,
 				Histograms: histograms,
@@ -370,11 +385,17 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 			}
 		}
 	case promql.Scalar:
+		seriesCount = 1
+		sampleCount = 1
 		series := &prompb.TimeSeries{Samples: []prompb.Sample{{Value: float64(results.V), Timestamp: int64(results.T)}}}
 		if err := srv.Send(querypb.NewQueryRangeResponse(series)); err != nil {
 			return err
 		}
 	}
+	span.SetAttributes(
+		attribute.Int64("result.series", seriesCount),
+		attribute.Int64("result.samples", sampleCount),
+	)
 
 	if stats := qry.Stats(); stats != nil {
 		if err := srv.Send(querypb.NewQueryRangeStatsResponse(toQueryStats(stats))); err != nil {

--- a/api/grpc/thanos.go
+++ b/api/grpc/thanos.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/prometheus/tsdb/chunks"
 	"github.com/prometheus/prometheus/util/annotations"
 	"github.com/prometheus/prometheus/util/stats"
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -32,6 +33,7 @@ import (
 
 	"github.com/thanos-io/thanos-parquet-gateway/db"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/limits"
+	"github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/warnings"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
 )
@@ -239,6 +241,11 @@ func (qs *QueryServer) Query(req *querypb.QueryRequest, srv querypb.Query_QueryS
 	ctx, cancel := context.WithTimeout(srv.Context(), timeout)
 	defer cancel()
 
+	span := tracing.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("query.expr", req.Query),
+	)
+
 	if err := qs.concurrentQuerySemaphore.Reserve(ctx); err != nil {
 		return status.Error(codes.Aborted, fmt.Sprintf("semaphore blocked: %s", err))
 	}
@@ -303,6 +310,11 @@ func (qs *QueryServer) QueryRange(req *querypb.QueryRangeRequest, srv querypb.Qu
 
 	ctx, cancel := context.WithTimeout(srv.Context(), timeout)
 	defer cancel()
+
+	span := tracing.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("query.expr", req.Query),
+	)
 
 	if err := qs.concurrentQuerySemaphore.Reserve(ctx); err != nil {
 		return status.Error(codes.Aborted, fmt.Sprintf("semaphore blocked: %s", err))

--- a/api/http/query.go
+++ b/api/http/query.go
@@ -478,10 +478,12 @@ func (qapi *queryAPI) query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Add result metrics to span
-	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
+	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
 	span.SetAttributes(
 		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.samples", sampleCount),
+		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
+		attribute.Int64("result.float_samples", floatSampleCount),
+		attribute.Int64("result.histogram_samples", histogramSampleCount),
 	)
 	writeQueryResponse(w, res, qapi.l)
 }
@@ -569,10 +571,12 @@ func (qapi *queryAPI) queryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Add result metrics to span
-	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
+	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
 	span.SetAttributes(
 		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.samples", sampleCount),
+		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
+		attribute.Int64("result.float_samples", floatSampleCount),
+		attribute.Int64("result.histogram_samples", histogramSampleCount),
 	)
 	writeQueryResponse(w, res, qapi.l)
 }

--- a/api/http/query.go
+++ b/api/http/query.go
@@ -407,6 +407,25 @@ func (qapi *queryAPI) queryable() storage.Queryable {
 	)
 }
 
+// computeResultMetrics returns series and sample counts for a PromQL query result.
+func computeResultMetrics(value parser.Value) (seriesCount, sampleCount int64) {
+	switch results := value.(type) {
+	case promql.Vector:
+		seriesCount = int64(len(results))
+		sampleCount = int64(len(results))
+	case promql.Matrix:
+		seriesCount = int64(len(results))
+		for _, series := range results {
+			sampleCount += int64(len(series.Floats))
+			sampleCount += int64(len(series.Histograms))
+		}
+	case promql.Scalar:
+		seriesCount = 1
+		sampleCount = 1
+	}
+	return
+}
+
 func (qapi *queryAPI) query(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	span := tracing.SpanFromContext(ctx)
@@ -476,6 +495,12 @@ func (qapi *queryAPI) query(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Add result metrics to span
+	seriesCount, sampleCount := computeResultMetrics(res.Value)
+	span.SetAttributes(
+		attribute.Int64("result.series", seriesCount),
+		attribute.Int64("result.samples", sampleCount),
+	)
 	writeQueryResponse(w, res, qapi.l)
 }
 
@@ -561,6 +586,12 @@ func (qapi *queryAPI) queryRange(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Add result metrics to span
+	seriesCount, sampleCount := computeResultMetrics(res.Value)
+	span.SetAttributes(
+		attribute.Int64("result.series", seriesCount),
+		attribute.Int64("result.samples", sampleCount),
+	)
 	writeQueryResponse(w, res, qapi.l)
 }
 

--- a/api/http/query.go
+++ b/api/http/query.go
@@ -680,6 +680,10 @@ func (qapi *queryAPI) series(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	span.SetAttributes(
+		attribute.Int("result.series", len(series)),
+	)
+
 	writeSeriesResponse(w, series, annos, qapi.l)
 }
 

--- a/api/http/query.go
+++ b/api/http/query.go
@@ -478,13 +478,7 @@ func (qapi *queryAPI) query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Add result metrics to span
-	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
-	span.SetAttributes(
-		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
-		attribute.Int64("result.float_samples", floatSampleCount),
-		attribute.Int64("result.histogram_samples", histogramSampleCount),
-	)
+	util.InjectResultMetrics(span, res.Value)
 	writeQueryResponse(w, res, qapi.l)
 }
 
@@ -571,13 +565,7 @@ func (qapi *queryAPI) queryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Add result metrics to span
-	seriesCount, floatSampleCount, histogramSampleCount := util.ComputeResultMetrics(res.Value)
-	span.SetAttributes(
-		attribute.Int64("result.series", seriesCount),
-		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
-		attribute.Int64("result.float_samples", floatSampleCount),
-		attribute.Int64("result.histogram_samples", histogramSampleCount),
-	)
+	util.InjectResultMetrics(span, res.Value)
 	writeQueryResponse(w, res, qapi.l)
 }
 

--- a/api/http/query.go
+++ b/api/http/query.go
@@ -407,24 +407,6 @@ func (qapi *queryAPI) queryable() storage.Queryable {
 	)
 }
 
-// computeResultMetrics returns series and sample counts for a PromQL query result.
-func computeResultMetrics(value parser.Value) (seriesCount, sampleCount int64) {
-	switch results := value.(type) {
-	case promql.Vector:
-		seriesCount = int64(len(results))
-		sampleCount = int64(len(results))
-	case promql.Matrix:
-		seriesCount = int64(len(results))
-		for _, series := range results {
-			sampleCount += int64(len(series.Floats))
-			sampleCount += int64(len(series.Histograms))
-		}
-	case promql.Scalar:
-		seriesCount = 1
-		sampleCount = 1
-	}
-	return
-}
 
 func (qapi *queryAPI) query(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -496,7 +478,7 @@ func (qapi *queryAPI) query(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Add result metrics to span
-	seriesCount, sampleCount := computeResultMetrics(res.Value)
+	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
 	span.SetAttributes(
 		attribute.Int64("result.series", seriesCount),
 		attribute.Int64("result.samples", sampleCount),
@@ -587,7 +569,7 @@ func (qapi *queryAPI) queryRange(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Add result metrics to span
-	seriesCount, sampleCount := computeResultMetrics(res.Value)
+	seriesCount, sampleCount := util.ComputeResultMetrics(res.Value)
 	span.SetAttributes(
 		attribute.Int64("result.series", seriesCount),
 		attribute.Int64("result.samples", sampleCount),

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -14,14 +14,6 @@ import (
 	"regexp"
 	"time"
 
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/jaeger" //nolint:staticcheck
-	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
-	"go.opentelemetry.io/otel/sdk/resource"
-	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
-	"go.opentelemetry.io/otel/trace/noop"
-
 	"github.com/alecthomas/units"
 	"github.com/oklog/run"
 	"github.com/prometheus/client_golang/prometheus"
@@ -136,56 +128,72 @@ func setupTracing(ctx context.Context, logger *slog.Logger, opts tracingOpts) er
 		return cftracing.SetupTracingFromConfig(ctx, logger, confContentYaml)
 	}
 
-	// Fall back to legacy flag-based configuration
-	var (
-		exporter trace.SpanExporter
-		err      error
-	)
-	switch opts.exporterType {
-	case "JAEGER":
-		exporter, err = jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(opts.jaegerEndpoint)))
-		if err != nil {
-			return err
-		}
-	case "STDOUT":
-		exporter, err = stdouttrace.New()
-		if err != nil {
-			return err
-		}
-	case "":
-		otel.SetTracerProvider(noop.NewTracerProvider())
-		return nil
-	default:
-		return fmt.Errorf("invalid exporter type %s", opts.exporterType)
-	}
-	var sampler trace.Sampler
-	switch opts.samplingType {
-	case "PROBABILISTIC":
-		sampler = trace.TraceIDRatioBased(opts.samplingParam)
-	case "ALWAYS":
-		sampler = trace.AlwaysSample()
-	case "NEVER":
-		sampler = trace.NeverSample()
-	default:
-		return fmt.Errorf("invalid sampling type %s", opts.samplingType)
-	}
-	r, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName("parquet-gateway"),
-			semconv.ServiceVersion("v0.0.0"),
-		),
-	)
+	// Convert legacy flag-based configuration to TracingConfig
+	tracingConfig, err := convertLegacyTracingFlags(logger, opts)
 	if err != nil {
 		return err
 	}
 
-	tracerProvider := trace.NewTracerProvider(
-		trace.WithSampler(trace.ParentBased(sampler)),
-		trace.WithBatcher(exporter),
-		trace.WithResource(r),
-	)
-	otel.SetTracerProvider(tracerProvider)
-	return nil
+	// Use the parsed config loader to avoid serialization/deserialization
+	return cftracing.SetupTracingFromParsedConfig(ctx, logger, tracingConfig)
+}
+
+// convertLegacyTracingFlags converts legacy flag-based tracing configuration
+// to the new TracingConfig format.
+func convertLegacyTracingFlags(logger *slog.Logger, opts tracingOpts) (*cftracing.TracingConfig, error) {
+	// Handle no tracing
+	if opts.exporterType == "" {
+		return &cftracing.TracingConfig{}, nil
+	}
+
+	// Handle STDOUT - not supported by thanos packages
+	if opts.exporterType == "STDOUT" {
+		logger.Warn("STDOUT tracing is not supported by file-based configuration. Tracing will be disabled. Please use OTLP or JAEGER providers instead.")
+		return &cftracing.TracingConfig{}, nil
+	}
+
+	// Handle JAEGER
+	if opts.exporterType == "JAEGER" {
+		config := map[string]any{
+			"service_name": "parquet-gateway",
+		}
+
+		// Add endpoint if provided
+		if opts.jaegerEndpoint != "" {
+			config["endpoint"] = opts.jaegerEndpoint
+		}
+
+		// Convert sampling type
+		samplerType, samplerParam := convertSamplingToJaeger(opts.samplingType, opts.samplingParam)
+		if samplerType != "" {
+			config["sampler_type"] = samplerType
+		}
+		if samplerParam != 0 {
+			config["sampler_param"] = samplerParam
+		}
+
+		return &cftracing.TracingConfig{
+			Type:   cftracing.ProviderJaeger,
+			Config: config,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("invalid exporter type %s", opts.exporterType)
+}
+
+// convertSamplingToJaeger converts legacy sampling configuration to Jaeger-compatible format.
+func convertSamplingToJaeger(samplingType string, samplingParam float64) (string, float64) {
+	switch samplingType {
+	case "PROBABILISTIC":
+		return "probabilistic", samplingParam
+	case "ALWAYS":
+		return "const", 1.0
+	case "NEVER":
+		return "const", 0.0
+	default:
+		// Default to const sampler with always sample
+		return "const", 1.0
+	}
 }
 
 type apiOpts struct {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/thanos-io/objstore/client"
 	"github.com/thanos-io/thanos/pkg/runutil"
 
+	cftracing "github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
 	"github.com/thanos-io/thanos-parquet-gateway/locate"
 )
 
@@ -102,6 +103,11 @@ func (s slogAdapter) Log(args ...any) error {
 }
 
 type tracingOpts struct {
+	// Config file options (Thanos-compatible)
+	configFile string
+	config     string
+
+	// Legacy flag-based options
 	exporterType string
 
 	// jaeger opts
@@ -111,7 +117,26 @@ type tracingOpts struct {
 	samplingType  string
 }
 
-func setupTracing(ctx context.Context, opts tracingOpts) error {
+func setupTracing(ctx context.Context, logger *slog.Logger, opts tracingOpts) error {
+	// First, check if config file is provided (Thanos-compatible format)
+	if opts.configFile != "" || opts.config != "" {
+		var confContentYaml []byte
+		var err error
+
+		if opts.configFile != "" {
+			confContentYaml, err = os.ReadFile(opts.configFile)
+			if err != nil {
+				return fmt.Errorf("unable to read tracing config file: %w", err)
+			}
+		} else {
+			confContentYaml = []byte(opts.config)
+		}
+
+		confContentYaml = ExpandEnvParens(confContentYaml)
+		return cftracing.SetupTracingFromConfig(ctx, logger, confContentYaml)
+	}
+
+	// Fall back to legacy flag-based configuration
 	var (
 		exporter trace.SpanExporter
 		err      error

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -72,10 +72,13 @@ func (opts *bucketOpts) registerServeFlags(cmd *kingpin.CmdClause) {
 }
 
 func (opts *tracingOpts) registerServeFlags(cmd *kingpin.CmdClause) {
-	cmd.Flag("tracing.exporter.type", "type of tracing exporter").Default("").EnumVar(&opts.exporterType, "JAEGER", "STDOUT", "")
-	cmd.Flag("tracing.jaeger.endpoint", "endpoint to send traces, eg. https://example.com:4318/v1/traces").StringVar(&opts.jaegerEndpoint)
-	cmd.Flag("tracing.sampling.param", "sample of traces to send").Default("0.1").Float64Var(&opts.samplingParam)
-	cmd.Flag("tracing.sampling.type", "type of sampling").Default("PROBABILISTIC").EnumVar(&opts.samplingType, "PROBABILISTIC", "ALWAYS", "NEVER")
+	cmd.Flag("tracing.config-file", "Path to YAML file with tracing configuration. See format details: https://thanos.io/tip/thanos/tracing.md/").StringVar(&opts.configFile)
+	cmd.Flag("tracing.config", "Alternative to 'tracing.config-file'. YAML content for tracing configuration.").StringVar(&opts.config)
+	// Command line tracing config flags are deprecated in favour of the tracing config file
+	cmd.Flag("tracing.exporter.type", "type of tracing exporter: [\"\", \"JAEGER\", \"STDOUT\"]. Default: \"\"\nDEPRECATED: prefer --tracing.config or --tracing.config-file").Default("").Hidden().EnumVar(&opts.exporterType, "JAEGER", "STDOUT", "")
+	cmd.Flag("tracing.jaeger.endpoint", "endpoint to send traces, eg. https://example.com:4318/v1/traces\nDEPRECATED: prefer --tracing.config or --tracing.config-file").Hidden().StringVar(&opts.jaegerEndpoint)
+	cmd.Flag("tracing.sampling.param", "sample of traces to send\nDEPRECATED: prefer --tracing.config or --tracing.config-file").Default("0.1").Hidden().Float64Var(&opts.samplingParam)
+	cmd.Flag("tracing.sampling.type", "type of sampling\nDEPRECATED: prefer --tracing.config or --tracing.config-file").Default("PROBABILISTIC").Hidden().EnumVar(&opts.samplingType, "PROBABILISTIC", "ALWAYS", "NEVER")
 }
 
 func (opts *discoveryOpts) registerServeFlags(cmd *kingpin.CmdClause) {
@@ -140,7 +143,7 @@ func registerServeApp(app *kingpin.Application) (*kingpin.CmdClause, func(contex
 
 		setupInterrupt(ctx, &g, log)
 
-		if err := setupTracing(ctx, opts.tracing); err != nil {
+		if err := setupTracing(ctx, log, opts.tracing); err != nil {
 			return fmt.Errorf("unable to setup tracing: %w", err)
 		}
 

--- a/db/block.go
+++ b/db/block.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos-parquet-gateway/internal/limits"
+	matcherspkg "github.com/thanos-io/thanos-parquet-gateway/internal/matchers"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/warnings"
@@ -208,7 +209,7 @@ func (q BlockQuerier) selectFn(ctx context.Context, _ bool, hints *storage.Selec
 	defer span.End()
 
 	span.SetAttributes(attribute.Bool("sorted", true))
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.Int("block.shards", len(q.shards)))
 	span.SetAttributes(attribute.String("block.mint", time.UnixMilli(q.mint).String()))
 	span.SetAttributes(attribute.String("block.maxt", time.UnixMilli(q.maxt).String()))
@@ -239,7 +240,7 @@ func (q *BlockChunkQuerier) selectChunksFn(ctx context.Context, _ bool, hints *s
 	defer span.End()
 
 	span.SetAttributes(attribute.Bool("sorted", true))
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.Int("block.shards", len(q.shards)))
 
 	sss := make([]storage.ChunkSeriesSet, 0, len(q.shards))

--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/thanos-io/thanos-parquet-gateway/internal/limits"
+	matcherspkg "github.com/thanos-io/thanos-parquet-gateway/internal/matchers"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/warnings"
@@ -391,7 +392,7 @@ func (q DBQuerier) selectFn(ctx context.Context, sorted bool, hints *storage.Sel
 	defer span.End()
 
 	span.SetAttributes(attribute.Bool("sorted", sorted))
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.Int("block.shards", len(q.blocks)))
 
 	// If we need to merge multiple series sets vertically we need them sorted
@@ -431,7 +432,7 @@ func (q *DBChunkQuerier) selectChunksFn(ctx context.Context, sorted bool, hints 
 	defer span.End()
 
 	span.SetAttributes(attribute.Bool("sorted", sorted))
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.Int("block.shards", len(q.blocks)))
 
 	// If we need to merge multiple series sets vertically we need them sorted

--- a/db/shard.go
+++ b/db/shard.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/thanos-io/thanos-parquet-gateway/internal/limits"
+	matcherspkg "github.com/thanos-io/thanos-parquet-gateway/internal/matchers"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/tracing"
 	"github.com/thanos-io/thanos-parquet-gateway/internal/warnings"
 	"github.com/thanos-io/thanos-parquet-gateway/schema"
@@ -130,7 +131,7 @@ func (q ShardQuerier) LabelValues(ctx context.Context, name string, hints *stora
 	ctx, span := tracing.Tracer().Start(ctx, "Label Values Shard")
 	defer span.End()
 
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.StringSlice("shard.replica_labels", q.replicaLabelNames))
 	span.SetAttributes(attribute.String("shard.external_labels", q.extlabels.String()))
 
@@ -164,7 +165,7 @@ func (q ShardQuerier) LabelNames(ctx context.Context, hints *storage.LabelHints,
 	ctx, span := tracing.Tracer().Start(ctx, "Label Names Shard")
 	defer span.End()
 
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.StringSlice("shard.replica_labels", q.replicaLabelNames))
 	span.SetAttributes(attribute.String("shard.external_labels", q.extlabels.String()))
 
@@ -198,20 +199,12 @@ func (q ShardQuerier) Select(ctx context.Context, sorted bool, hints *storage.Se
 	return newLazySeriesSet(ctx, q.selectFn, sorted, hints, matchers...)
 }
 
-func matchersToStringSlice(matchers []*labels.Matcher) []string {
-	res := make([]string, len(matchers))
-	for i := range matchers {
-		res[i] = matchers[i].String()
-	}
-	return res
-}
-
 func (q ShardQuerier) selectCore(ctx context.Context, spanName string, sorted bool, hints *storage.SelectHints, matchers ...*labels.Matcher) ([]search.SeriesChunks, annotations.Annotations, error) {
 	ctx, span := tracing.Tracer().Start(ctx, spanName)
 	defer span.End()
 
 	span.SetAttributes(attribute.Bool("sorted", sorted))
-	span.SetAttributes(attribute.StringSlice("matchers", matchersToStringSlice(matchers)))
+	span.SetAttributes(attribute.StringSlice("matchers", matcherspkg.ToStringSlice(matchers)))
 	span.SetAttributes(attribute.StringSlice("shard.replica_labels", q.replicaLabelNames))
 	span.SetAttributes(attribute.String("shard.external_labels", q.extlabels.String()))
 

--- a/docs/tracing/TRACING.md
+++ b/docs/tracing/TRACING.md
@@ -1,0 +1,146 @@
+# Tracing Configuration
+
+The thanos-parquet-gateway supports distributed tracing using OpenTelemetry. There are two ways to configure tracing:
+
+## 1. Thanos-Compatible Configuration File (Recommended)
+
+Use a YAML configuration file that follows the [Thanos tracing configuration format](https://thanos.io/tip/thanos/tracing.md/#opentelemetry-otlp).
+
+### Usage
+
+```bash
+./thanos-parquet-gateway serve \
+  --tracing.config-file=/path/to/tracing-config.yaml \
+  --parquet.objstore-config-file=/path/to/bucket-config.yaml
+```
+
+Or provide the configuration inline:
+
+```bash
+./thanos-parquet-gateway serve \
+  --tracing.config='
+type: OTLP
+config:
+  client_type: grpc
+  service_name: parquet-gateway
+  endpoint: localhost:4317
+  insecure: true
+  sampler_type: parentbasedtraceidratiobased
+  sampler_param: "0.1"
+' \
+  --parquet.objstore-config-file=/path/to/bucket-config.yaml
+```
+
+### Configuration Format
+
+```yaml
+# Tracing provider type: OTLP or JAEGER
+type: OTLP
+
+config:
+  # OTLP client type: grpc or http
+  client_type: grpc
+
+  # Service name for traces
+  service_name: parquet-gateway
+
+  # Additional resource attributes
+  resource_attributes:
+    environment: production
+    version: v1.0.0
+
+  # OTLP endpoint (host:port without protocol)
+  endpoint: localhost:4317
+
+  # Use insecure connection (no TLS)
+  insecure: true
+
+  # Optional: compression (gzip)
+  compression: gzip
+
+  # Optional: custom headers
+  headers:
+    authorization: "Bearer $(AUTH_TOKEN)"
+
+  # Optional: timeout
+  timeout: 10s
+
+  # Sampler configuration
+  # Types: alwayssample, neversample, traceidratiobased,
+  #        parentbasedalwayssample, parentbasedneversample,
+  #        parentbasedtraceidratiobased
+  sampler_type: parentbasedtraceidratiobased
+  sampler_param: "0.1"  # 10% sampling rate
+```
+
+### Environment Variable Expansion
+
+Configuration files support environment variable expansion using the `$(VAR_NAME)` syntax:
+
+```yaml
+type: OTLP
+config:
+  endpoint: $(OTEL_EXPORTER_OTLP_ENDPOINT)
+  headers:
+    authorization: "Bearer $(AUTH_TOKEN)"
+```
+
+### Sampler Types
+
+- **alwayssample** / **always**: Sample all traces
+- **neversample** / **never**: Never sample traces
+- **traceidratiobased** / **probabilistic**: Sample based on trace ID ratio (requires `sampler_param`)
+- **parentbasedalwayssample**: Respect parent sampling decision, always sample if no parent
+- **parentbasedneversample**: Respect parent sampling decision, never sample if no parent
+- **parentbasedtraceidratiobased**: Respect parent sampling decision, use ratio-based sampling if no parent
+
+### Examples
+
+See the included example files:
+- `tracing-config-example.yaml` - Full OTLP configuration example
+- `tracing-config-stdout-example.yaml` - Simple stdout tracer for debugging
+
+## 2. Legacy Flag-Based Configuration
+
+For backward compatibility, you can still use individual flags:
+
+```bash
+./thanos-parquet-gateway serve \
+  --tracing.exporter.type=OTLP \
+  --tracing.otlp.protocol=grpc \
+  --tracing.otlp.endpoint=localhost:4317 \
+  --tracing.otlp.insecure \
+  --tracing.sampling.type=PROBABILISTIC \
+  --tracing.sampling.param=0.1 \
+  --parquet.objstore-config-file=/path/to/bucket-config.yaml
+```
+
+### Available Flags
+
+- `--tracing.exporter.type`: Exporter type (OTLP, JAEGER, or empty for no tracing)
+- `--tracing.jaeger.endpoint`: Jaeger collector endpoint
+- `--tracing.otlp.protocol`: OTLP protocol (grpc or http)
+- `--tracing.otlp.endpoint`: OTLP endpoint (host:port)
+- `--tracing.otlp.insecure`: Use insecure connection
+- `--tracing.sampling.type`: Sampling type (PROBABILISTIC, ALWAYS, NEVER)
+- `--tracing.sampling.param`: Sampling parameter (0.0-1.0 for PROBABILISTIC)
+
+## Trace Attributes
+
+The parquet-gateway automatically adds the following trace attributes to relevant spans:
+
+### Query Operations
+- `series.selector`: Series selector matchers
+- `result.series`: Number of series in result
+- `result.samples`: Number of samples in result
+- `result.histograms`: Number of histogram samples in result
+- `result.memory_bytes`: Estimated memory usage of result
+- `result.wire_bytes`: Size of gRPC wire protocol response
+
+### Series Operations
+- `series.selector`: Series selector matchers
+- `series.count`: Number of series returned
+- `series.sample_count`: Total number of samples
+- `result.wire_bytes`: Size of gRPC wire protocol response
+
+These attributes are automatically computed and added when trace spans are recording.

--- a/docs/tracing/tracing-config-example.yaml
+++ b/docs/tracing/tracing-config-example.yaml
@@ -1,0 +1,47 @@
+# Example Thanos-compatible tracing configuration for thanos-parquet-gateway
+# See: https://thanos.io/tip/thanos/tracing.md/#opentelemetry-otlp
+
+# Tracing provider type. Supported: OTLP, STDOUT
+type: OTLP
+
+config:
+  # Client type: grpc or http
+  client_type: grpc
+
+  # Service name for traces
+  service_name: parquet-gateway
+
+  # Additional resource attributes to attach to all spans
+  resource_attributes:
+    environment: production
+    version: v1.0.0
+
+  # OTLP endpoint (host:port, without protocol scheme)
+  endpoint: localhost:4317
+
+  # Use insecure connection (no TLS)
+  insecure: true
+
+  # Optional: compression (gzip)
+  # compression: gzip
+
+  # Optional: custom headers for authentication
+  # headers:
+  #   authorization: "Bearer token123"
+
+  # Optional: timeout for sending traces
+  # timeout: 10s
+
+  # Sampling configuration
+  # Supported sampler types:
+  #   - alwayssample / always: Always sample all traces
+  #   - neversample / never: Never sample traces
+  #   - traceidratiobased / probabilistic: Sample based on trace ID ratio
+  #   - parentbasedalwayssample: Parent-based with always sample fallback
+  #   - parentbasedneversample: Parent-based with never sample fallback
+  #   - parentbasedtraceidratiobased: Parent-based with ratio-based fallback
+  sampler_type: parentbasedtraceidratiobased
+
+  # Sampling parameter (used with ratio-based samplers)
+  # Value between 0.0 (0%) and 1.0 (100%)
+  sampler_param: "0.1"

--- a/docs/tracing/tracing-config-jaeger-example.yaml
+++ b/docs/tracing/tracing-config-jaeger-example.yaml
@@ -1,0 +1,48 @@
+# Example Jaeger tracing configuration for thanos-parquet-gateway
+# This configuration uses the Thanos jaeger package (github.com/thanos-io/thanos/pkg/tracing/jaeger)
+# which provides comprehensive Jaeger integration with OpenTelemetry.
+
+type: JAEGER
+config:
+  # Service name identifies this service in traces
+  service_name: parquet-gateway
+
+  # Jaeger endpoint configuration
+  # Option 1: Use collector endpoint (HTTP/HTTPS)
+  endpoint: http://jaeger-collector:14268/api/traces
+  # Optional: username for collector authentication
+  # user: username
+  # Optional: password for collector authentication
+  # password: password
+
+  # Option 2: Use agent endpoint (UDP)
+  # Uncomment these and comment out 'endpoint' to use agent
+  # agent_host: localhost
+  # agent_port: 6831
+
+  # Sampling configuration
+  # Sampler types: const, probabilistic, ratelimiting, remote
+  sampler_type: const
+  # For const: 0 (never sample) or 1 (always sample)
+  # For probabilistic: 0.0 to 1.0 (sampling probability)
+  # For ratelimiting: number of traces per second
+  sampler_param: 1
+
+  # Optional: Remote sampling configuration
+  # sampling_server_url: http://jaeger-agent:5778/sampling
+  # sampler_refresh_interval: 1m
+  # initial_sampler_rate: 0.001
+
+  # Optional: Reporter configuration
+  # reporter_max_queue_size: 100
+  # reporter_flush_interval: 1s
+  # reporter_log_spans: false
+
+  # Optional: Additional tags (comma-separated key=value pairs)
+  # Supports environment variable substitution: ${ENV_VAR:default_value}
+  # tags: environment=production,region=${REGION:us-east-1}
+
+  # Optional: Parent-based sampler configuration
+  # sampler_parent_config:
+  #   local_parent_sampled: false
+  #   remote_parent_sampled: false

--- a/docs/tracing/tracing-config-otlp-example.yaml
+++ b/docs/tracing/tracing-config-otlp-example.yaml
@@ -1,0 +1,65 @@
+# Example OTLP tracing configuration for thanos-parquet-gateway
+# This configuration uses the Thanos OTLP package (github.com/thanos-io/thanos/pkg/tracing/otlp)
+# which provides comprehensive OTLP integration with OpenTelemetry.
+
+type: OTLP
+config:
+  # Client type: "grpc" or "http"
+  client_type: grpc
+
+  # Service name identifies this service in traces
+  service_name: parquet-gateway
+
+  # OTLP collector endpoint (without protocol prefix)
+  # For gRPC: typically "collector:4317"
+  # For HTTP: typically "collector:4318"
+  endpoint: localhost:4317
+
+  # Use insecure connection (no TLS)
+  insecure: true
+
+  # Optional: URL path for HTTP client (default: /v1/traces)
+  # url_path: /v1/traces
+
+  # Optional: Compression type ("gzip" or empty for no compression)
+  # compression: gzip
+
+  # Optional: Connection timeout
+  # timeout: 10s
+
+  # Optional: Reconnection period for gRPC client
+  # reconnection_period: 30s
+
+  # Optional: Additional resource attributes
+  # resource_attributes:
+  #   environment: production
+  #   region: us-east-1
+  #   cluster: main
+
+  # Optional: Custom headers for authentication
+  # headers:
+  #   Authorization: Bearer token123
+  #   X-Custom-Header: value
+
+  # Sampling configuration
+  # Sampler types: alwayssample, neversample, traceidratiobased,
+  #                parentbasedalwayssample, parentbasedneversample,
+  #                parentbasedtraceidratiobased
+  sampler_type: alwayssample
+  # For traceidratiobased samplers, specify sampling ratio (0.0 to 1.0)
+  # sampler_param: "0.1"
+
+  # Optional: Retry configuration
+  # retry_config:
+  #   retry_enabled: true
+  #   retry_initial_interval: 5s
+  #   retry_max_interval: 30s
+  #   retry_max_elapsed_time: 5m
+
+  # Optional: TLS configuration (when insecure: false)
+  # tls_config:
+  #   ca_file: /path/to/ca.pem
+  #   cert_file: /path/to/cert.pem
+  #   key_file: /path/to/key.pem
+  #   server_name: collector.example.com
+  #   insecure_skip_verify: false

--- a/go.mod
+++ b/go.mod
@@ -26,8 +26,6 @@ require (
 	go.opentelemetry.io/contrib/propagators/autoprop v0.61.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.32.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	google.golang.org/protobuf v1.36.9
@@ -38,7 +36,9 @@ require (
 	github.com/VictoriaMetrics/easyproto v0.1.4 // indirect
 	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/caio/go-tdigest v3.1.0+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
+	github.com/cristalhq/hedgedhttp v0.9.1 // indirect
 	github.com/efficientgo/tools/extkingpin v0.0.0-20230505153745-6b7392939a60 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
@@ -107,6 +107,8 @@ require (
 	go.opentelemetry.io/contrib/samplers/jaegerremote v0.30.0 // indirect
 	go.opentelemetry.io/otel/bridge/opentracing v1.36.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/KimMachineGun/automemlimit v0.7.3
 	github.com/cortexproject/promqlsmith v0.0.0-20250407233056-90db95b1a4e4
+	github.com/go-kit/log v0.2.1
 	github.com/google/go-cmp v0.7.0
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1
 	github.com/json-iterator/go v1.1.12
@@ -25,6 +26,8 @@ require (
 	go.opentelemetry.io/contrib/propagators/autoprop v0.61.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.32.0
 	go.opentelemetry.io/otel/sdk v1.36.0
 	google.golang.org/protobuf v1.36.9
@@ -35,10 +38,10 @@ require (
 	github.com/VictoriaMetrics/easyproto v0.1.4 // indirect
 	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/efficientgo/tools/extkingpin v0.0.0-20230505153745-6b7392939a60 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.5 // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-openapi/analysis v0.23.0 // indirect
 	github.com/go-openapi/errors v0.22.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
@@ -50,9 +53,12 @@ require (
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
+	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
+	github.com/jaegertracing/jaeger-idl v0.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/knadh/koanf/providers/confmap v1.0.0 // indirect
@@ -98,8 +104,11 @@ require (
 	go.opentelemetry.io/contrib/propagators/b3 v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/jaeger v1.36.0 // indirect
 	go.opentelemetry.io/contrib/propagators/ot v1.36.0 // indirect
+	go.opentelemetry.io/contrib/samplers/jaegerremote v0.30.0 // indirect
 	go.opentelemetry.io/otel/bridge/opentracing v1.36.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect
 	go.opentelemetry.io/otel/log v0.12.2 // indirect
+	go.opentelemetry.io/proto/otlp v1.7.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
@@ -219,7 +228,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/grpc v1.73.0
-	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.33.1 // indirect
 	k8s.io/client-go v0.33.1 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
 github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
+github.com/caio/go-tdigest v3.1.0+incompatible h1:uoVMJ3Q5lXmVLCCqaMGHLBWnbGoN6Lpu7OAUPR60cds=
+github.com/caio/go-tdigest v3.1.0+incompatible/go.mod h1:sHQM/ubZStBUmF1WbB8FAm8q9GjDajLC5T7ydxE3JHI=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -181,6 +183,8 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/cortexproject/promqlsmith v0.0.0-20250407233056-90db95b1a4e4 h1:dpo7kQ24uFSV6Zgm9/kB34TIUWjGmadlbKrM6fNfQko=
 github.com/cortexproject/promqlsmith v0.0.0-20250407233056-90db95b1a4e4/go.mod h1:jh6POgN18lXU133HBMfwr/1TjvBp8e5kL4ZtRsAPvGY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cristalhq/hedgedhttp v0.9.1 h1:g68L9cf8uUyQKQJwciD0A1Vgbsz+QgCjuB1I8FAsCDs=
+github.com/cristalhq/hedgedhttp v0.9.1/go.mod h1:XkqWU6qVMutbhW68NnzjWrGtH8NUx1UfYqGYtHVKIsI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -503,6 +507,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzWu4=
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
+github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353 h1:X/79QL0b4YJVO5+OsPH9rF2u428CIrGL/jLmPsoOQQ4=
+github.com/leesper/go_rng v0.0.0-20190531154944-a612b043e353/go.mod h1:N0SVk0uhy+E1PZ3C9ctsPRlvOPAFPkCNlcPBDkt0N3U=
 github.com/linode/linodego v1.52.2 h1:N9ozU27To1LMSrDd8WvJZ5STSz1eGYdyLnxhAR/dIZg=
 github.com/linode/linodego v1.52.2/go.mod h1:bI949fZaVchjWyKIA08hNyvAcV6BAS+PM2op3p7PAWA=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bluele/gcache v0.0.2 h1:WcbfdXICg7G/DGBh1PFfcirkWOQV+v077yF1pSy3DGw=
 github.com/bluele/gcache v0.0.2/go.mod h1:m15KV+ECjptwSPxKhOhQoAFQVtUFjTVkc3H8o0t/fp0=
+github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
+github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -287,6 +289,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
+github.com/gogo/googleapis v1.4.1 h1:1Yx4Myt7BxzvUr5ldGSbwYiZG6t9wGBZ+8/fX3Wvtq0=
+github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
@@ -395,6 +399,8 @@ github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod 
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4zG2vvqG6uWNkBHSTqXOZk0=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2/go.mod h1:wd1YpapPLivG6nQgbf7ZkG1hhSOXDhhn4MLTknx2aAc=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.32.0 h1:5wp5u780Gri7c4OedGEPzmlUEzi0g2KyiPphSr6zjVg=
 github.com/hashicorp/consul/api v1.32.0/go.mod h1:Z8YgY0eVPukT/17ejW+l+C7zJmKwgPHtjU1q16v/Y40=
@@ -452,6 +458,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/ionos-cloud/sdk-go/v6 v6.3.4 h1:jTvGl4LOF8v8OYoEIBNVwbFoqSGAFqn6vGE7sp7/BqQ=
 github.com/ionos-cloud/sdk-go/v6 v6.3.4/go.mod h1:wCVwNJ/21W29FWFUv+fNawOTMlFoP1dS3L+ZuztFW48=
+github.com/jaegertracing/jaeger-idl v0.6.0 h1:LOVQfVby9ywdMPI9n3hMwKbyLVV3BL1XH2QqsP5KTMk=
+github.com/jaegertracing/jaeger-idl v0.6.0/go.mod h1:mpW0lZfG907/+o5w5OlnNnig7nHJGT3SfKmRqC42HGQ=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -780,12 +788,20 @@ go.opentelemetry.io/contrib/propagators/jaeger v1.36.0 h1:SoCgXYF4ISDtNyfLUzsGDa
 go.opentelemetry.io/contrib/propagators/jaeger v1.36.0/go.mod h1:VHu48l0YTRKSObdPQ+Sb8xMZvdnJlN7yhHuHoPgNqHM=
 go.opentelemetry.io/contrib/propagators/ot v1.36.0 h1:UBoZjbx483GslNKYK2YpfvePTJV4BHGeFd8+b7dexiM=
 go.opentelemetry.io/contrib/propagators/ot v1.36.0/go.mod h1:adDDRry19/n9WoA7mSCMjoVJcmzK/bZYzX9SR+g2+W4=
+go.opentelemetry.io/contrib/samplers/jaegerremote v0.30.0 h1:bQ1Gvah4Sp8z7epSkgJaNTuZm7sutfA6Fji2/7cKFMc=
+go.opentelemetry.io/contrib/samplers/jaegerremote v0.30.0/go.mod h1:9b8Q9rH52NgYH3ShiTFB5wf18Vt3RTH/VMB7LDcC1ug=
 go.opentelemetry.io/otel v1.36.0 h1:UumtzIklRBY6cI/lllNZlALOF5nNIzJVb16APdvgTXg=
 go.opentelemetry.io/otel v1.36.0/go.mod h1:/TcFMXYjyRNh8khOAO9ybYkqaDBb/70aVwkNML4pP8E=
 go.opentelemetry.io/otel/bridge/opentracing v1.36.0 h1:GWGmcYhMCu6+K/Yz5KWSETU/esd/mkVGx+77uKtLjpk=
 go.opentelemetry.io/otel/bridge/opentracing v1.36.0/go.mod h1:bW7xTHgtWSNqY8QjhqXzloXBkw3iQIa8uBqCF/0EUbc=
 go.opentelemetry.io/otel/exporters/jaeger v1.17.0 h1:D7UpUy2Xc2wsi1Ras6V40q806WM07rqoCWzXu7Sqy+4=
 go.opentelemetry.io/otel/exporters/jaeger v1.17.0/go.mod h1:nPCqOnEH9rNLKqH/+rrUjiMzHJdV1BlpKcTwRTyKkKI=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 h1:dNzwXjZKpMpE2JhmO+9HsPl42NIXFIFSUSSs0fiqra0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0/go.mod h1:90PoxvaEB5n6AOdZvi+yWJQoE95U8Dhhw2bSyRqnTD0=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0 h1:JgtbA0xkWHnTmYk7YusopJFX6uleBmAuZ8n05NEh8nQ=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.36.0/go.mod h1:179AK5aar5R3eS9FucPy6rggvU0g52cvKId8pv4+v0c=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0 h1:nRVXXvf78e00EwY6Wp0YII8ww2JVWshZ20HfTlE11AM=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.36.0/go.mod h1:r49hO7CgrxY9Voaj3Xe8pANWtr0Oq916d0XAmOoCZAQ=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0 h1:WDdP9acbMYjbKIyJUhTvtzj601sVJOqgWdUxSdR/Ysc=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.29.0/go.mod h1:BLbf7zbNIONBLPwvFnwNHGj4zge8uTCM/UPIVW1Mq2I=
 go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.32.0 h1:cC2yDI3IQd0Udsux7Qmq8ToKAx1XCilTQECZ0KDZyTw=
@@ -802,6 +818,8 @@ go.opentelemetry.io/otel/sdk/metric v1.36.0 h1:r0ntwwGosWGaa0CrSt8cuNuTcccMXERFw
 go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRaW376QbB7P4Pb0qva4=
 go.opentelemetry.io/otel/trace v1.36.0 h1:ahxWNuqZjpdiFAyrIoQ4GIiAIhxAunQR6MUoKrsNd4w=
 go.opentelemetry.io/otel/trace v1.36.0/go.mod h1:gQ+OnDZzrybY4k4seLzPAWNwVBBVlF2szhehOBB/tGA=
+go.opentelemetry.io/proto/otlp v1.7.0 h1:jX1VolD6nHuFzOYso2E73H85i92Mv8JQYk0K9vz09os=
+go.opentelemetry.io/proto/otlp v1.7.0/go.mod h1:fSKjH6YJ7HDlwzltzyMj036AJ3ejJLCgCSHGj4efDDo=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=

--- a/internal/matchers/matchers.go
+++ b/internal/matchers/matchers.go
@@ -1,0 +1,16 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package matchers
+
+import "github.com/prometheus/prometheus/model/labels"
+
+// ToStringSlice converts a slice of Prometheus matchers to a slice of strings.
+func ToStringSlice(matchers []*labels.Matcher) []string {
+	res := make([]string, len(matchers))
+	for i := range matchers {
+		res[i] = matchers[i].String()
+	}
+	return res
+}

--- a/internal/matchers/matchers_test.go
+++ b/internal/matchers/matchers_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package matchers
+
+import (
+	"testing"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestToStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		matchers []*labels.Matcher
+		want     []string
+	}{
+		{
+			name:     "nil input",
+			matchers: nil,
+			want:     []string{},
+		},
+		{
+			name:     "empty input",
+			matchers: []*labels.Matcher{},
+			want:     []string{},
+		},
+		{
+			name: "single matcher",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "up"),
+			},
+			want: []string{`__name__="up"`},
+		},
+		{
+			name: "multiple matchers with different types",
+			matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__name__", "http_requests_total"),
+				labels.MustNewMatcher(labels.MatchNotEqual, "job", "test"),
+				labels.MustNewMatcher(labels.MatchRegexp, "instance", "localhost.*"),
+				labels.MustNewMatcher(labels.MatchNotRegexp, "env", "prod.*"),
+			},
+			want: []string{
+				`__name__="http_requests_total"`,
+				`job!="test"`,
+				`instance=~"localhost.*"`,
+				`env!~"prod.*"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ToStringSlice(tt.matchers)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(ToStringSlice()) = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ToStringSlice()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/tracing/config.go
+++ b/internal/tracing/config.go
@@ -1,0 +1,79 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package tracing
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/go-kit/log"
+	"github.com/thanos-io/thanos/pkg/tracing/jaeger"
+	"go.opentelemetry.io/otel"
+	"gopkg.in/yaml.v2"
+)
+
+// TracingProvider defines the type of tracing backend.
+type TracingProvider string
+
+const (
+	ProviderJaeger TracingProvider = "JAEGER"
+)
+
+// TracingConfig is the top-level config structure compatible with Thanos.
+type TracingConfig struct {
+	Type TracingProvider `yaml:"type"`
+}
+
+// slogToGoKitAdapter adapts slog.Logger to go-kit log.Logger interface.
+type slogToGoKitAdapter struct {
+	logger *slog.Logger
+}
+
+// Ensure slogToGoKitAdapter implements log.Logger interface.
+var _ log.Logger = (*slogToGoKitAdapter)(nil)
+
+// Log implements go-kit log.Logger interface.
+func (a slogToGoKitAdapter) Log(keyvals ...any) error {
+	// Convert keyvals to slog attributes
+	attrs := make([]slog.Attr, 0, len(keyvals)/2)
+	for i := 0; i < len(keyvals)-1; i += 2 {
+		key, ok := keyvals[i].(string)
+		if !ok {
+			continue
+		}
+		attrs = append(attrs, slog.Any(key, keyvals[i+1]))
+	}
+	a.logger.LogAttrs(context.Background(), slog.LevelInfo, "", attrs...)
+	return nil
+}
+
+// SetupTracingFromConfig initializes tracing from a YAML configuration.
+func SetupTracingFromConfig(ctx context.Context, logger *slog.Logger, confContentYaml []byte) error {
+	if len(confContentYaml) == 0 {
+		// No tracing configured
+		return nil
+	}
+
+	tracingConf := &TracingConfig{}
+	if err := yaml.Unmarshal(confContentYaml, tracingConf); err != nil {
+		return fmt.Errorf("parsing tracing YAML config: %w", err)
+	}
+
+	switch strings.ToUpper(string(tracingConf.Type)) {
+	case string(ProviderJaeger):
+		// Use thanos jaeger package to initialize tracing
+		goKitLogger := slogToGoKitAdapter{logger: logger}
+		tracerProvider, err := jaeger.NewTracerProvider(ctx, goKitLogger, confContentYaml)
+		if err != nil {
+			return fmt.Errorf("creating Jaeger tracer provider: %w", err)
+		}
+		otel.SetTracerProvider(tracerProvider)
+		return nil
+	default:
+		return fmt.Errorf("unsupported tracing provider: %s", tracingConf.Type)
+	}
+}

--- a/internal/tracing/config.go
+++ b/internal/tracing/config.go
@@ -27,8 +27,8 @@ const (
 
 // TracingConfig is the top-level config structure compatible with Thanos.
 type TracingConfig struct {
-	Type   TracingProvider    `yaml:"type"`
-	Config map[string]interface{} `yaml:"config"`
+	Type   TracingProvider `yaml:"type"`
+	Config map[string]any  `yaml:"config"`
 }
 
 // slogToGoKitAdapter adapts slog.Logger to go-kit log.Logger interface.
@@ -64,6 +64,18 @@ func SetupTracingFromConfig(ctx context.Context, logger *slog.Logger, confConten
 	tracingConf := &TracingConfig{}
 	if err := yaml.Unmarshal(confContentYaml, tracingConf); err != nil {
 		return fmt.Errorf("parsing tracing YAML config: %w", err)
+	}
+
+	return SetupTracingFromParsedConfig(ctx, logger, tracingConf)
+}
+
+// SetupTracingFromParsedConfig initializes tracing from a pre-parsed TracingConfig.
+// This avoids the need to serialize and deserialize configuration when building
+// config programmatically (e.g., from legacy flags).
+func SetupTracingFromParsedConfig(ctx context.Context, logger *slog.Logger, tracingConf *TracingConfig) error {
+	if tracingConf == nil || tracingConf.Type == "" {
+		// No tracing configured
+		return nil
 	}
 
 	// Extract the config section as YAML for the provider

--- a/internal/tracing/config.go
+++ b/internal/tracing/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/thanos-io/thanos/pkg/tracing/jaeger"
+	"github.com/thanos-io/thanos/pkg/tracing/otlp"
 	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v2"
 )
@@ -20,12 +21,14 @@ import (
 type TracingProvider string
 
 const (
+	ProviderOTLP   TracingProvider = "OTLP"
 	ProviderJaeger TracingProvider = "JAEGER"
 )
 
 // TracingConfig is the top-level config structure compatible with Thanos.
 type TracingConfig struct {
-	Type TracingProvider `yaml:"type"`
+	Type   TracingProvider    `yaml:"type"`
+	Config map[string]interface{} `yaml:"config"`
 }
 
 // slogToGoKitAdapter adapts slog.Logger to go-kit log.Logger interface.
@@ -63,11 +66,26 @@ func SetupTracingFromConfig(ctx context.Context, logger *slog.Logger, confConten
 		return fmt.Errorf("parsing tracing YAML config: %w", err)
 	}
 
+	// Extract the config section as YAML for the provider
+	configYaml, err := yaml.Marshal(tracingConf.Config)
+	if err != nil {
+		return fmt.Errorf("marshaling config section: %w", err)
+	}
+
 	switch strings.ToUpper(string(tracingConf.Type)) {
+	case string(ProviderOTLP):
+		// Use thanos OTLP package to initialize tracing
+		goKitLogger := slogToGoKitAdapter{logger: logger}
+		tracerProvider, err := otlp.NewTracerProvider(ctx, goKitLogger, configYaml)
+		if err != nil {
+			return fmt.Errorf("creating OTLP tracer provider: %w", err)
+		}
+		otel.SetTracerProvider(tracerProvider)
+		return nil
 	case string(ProviderJaeger):
 		// Use thanos jaeger package to initialize tracing
 		goKitLogger := slogToGoKitAdapter{logger: logger}
-		tracerProvider, err := jaeger.NewTracerProvider(ctx, goKitLogger, confContentYaml)
+		tracerProvider, err := jaeger.NewTracerProvider(ctx, goKitLogger, configYaml)
 		if err != nil {
 			return fmt.Errorf("creating Jaeger tracer provider: %w", err)
 		}

--- a/internal/tracing/config_test.go
+++ b/internal/tracing/config_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package tracing
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+)
+
+func TestSetupTracingFromConfig_Jaeger(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	yamlConfig := []byte(`
+type: JAEGER
+config:
+  service_name: test-service
+  sampler_type: const
+  sampler_param: 1
+`)
+
+	err := SetupTracingFromConfig(ctx, logger, yamlConfig)
+	if err != nil {
+		t.Fatalf("SetupTracingFromConfig failed: %v", err)
+	}
+
+	// Verify that a tracer provider was set
+	tracer := otel.GetTracerProvider()
+	if tracer == nil {
+		t.Fatal("Expected tracer provider to be set, but got nil")
+	}
+}
+
+func TestSetupTracingFromConfig_Empty(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	yamlConfig := []byte(``)
+
+	err := SetupTracingFromConfig(ctx, logger, yamlConfig)
+	if err != nil {
+		t.Fatalf("SetupTracingFromConfig failed with empty config: %v", err)
+	}
+}
+
+func TestSetupTracingFromConfig_InvalidType(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	yamlConfig := []byte(`
+type: INVALID_TYPE
+config:
+  service_name: test-service
+`)
+
+	err := SetupTracingFromConfig(ctx, logger, yamlConfig)
+	if err == nil {
+		t.Fatal("Expected error for invalid tracing type, but got nil")
+	}
+}

--- a/internal/tracing/config_test.go
+++ b/internal/tracing/config_test.go
@@ -13,6 +13,32 @@ import (
 	"go.opentelemetry.io/otel"
 )
 
+func TestSetupTracingFromConfig_OTLP(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	yamlConfig := []byte(`
+type: OTLP
+config:
+  client_type: grpc
+  service_name: test-service
+  endpoint: localhost:4317
+  insecure: true
+  sampler_type: alwayssample
+`)
+
+	err := SetupTracingFromConfig(ctx, logger, yamlConfig)
+	if err != nil {
+		t.Fatalf("SetupTracingFromConfig failed: %v", err)
+	}
+
+	// Verify that a tracer provider was set
+	tracer := otel.GetTracerProvider()
+	if tracer == nil {
+		t.Fatal("Expected tracer provider to be set, but got nil")
+	}
+}
+
 func TestSetupTracingFromConfig_Jaeger(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))

--- a/internal/tracing/config_test.go
+++ b/internal/tracing/config_test.go
@@ -90,3 +90,73 @@ config:
 		t.Fatal("Expected error for invalid tracing type, but got nil")
 	}
 }
+
+func TestSetupTracingFromParsedConfig_OTLP(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	tracingConf := &TracingConfig{
+		Type: ProviderOTLP,
+		Config: map[string]any{
+			"client_type":  "grpc",
+			"service_name": "test-service",
+			"endpoint":     "localhost:4317",
+			"insecure":     true,
+			"sampler_type": "alwayssample",
+		},
+	}
+
+	err := SetupTracingFromParsedConfig(ctx, logger, tracingConf)
+	if err != nil {
+		t.Fatalf("SetupTracingFromParsedConfig failed: %v", err)
+	}
+
+	// Verify that a tracer provider was set
+	tracer := otel.GetTracerProvider()
+	if tracer == nil {
+		t.Fatal("Expected tracer provider to be set, but got nil")
+	}
+}
+
+func TestSetupTracingFromParsedConfig_Jaeger(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	tracingConf := &TracingConfig{
+		Type: ProviderJaeger,
+		Config: map[string]any{
+			"service_name":  "test-service",
+			"sampler_type":  "const",
+			"sampler_param": float64(1),
+		},
+	}
+
+	err := SetupTracingFromParsedConfig(ctx, logger, tracingConf)
+	if err != nil {
+		t.Fatalf("SetupTracingFromParsedConfig failed: %v", err)
+	}
+
+	// Verify that a tracer provider was set
+	tracer := otel.GetTracerProvider()
+	if tracer == nil {
+		t.Fatal("Expected tracer provider to be set, but got nil")
+	}
+}
+
+func TestSetupTracingFromParsedConfig_Empty(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// Nil config
+	err := SetupTracingFromParsedConfig(ctx, logger, nil)
+	if err != nil {
+		t.Fatalf("SetupTracingFromParsedConfig failed with nil config: %v", err)
+	}
+
+	// Empty config
+	tracingConf := &TracingConfig{}
+	err = SetupTracingFromParsedConfig(ctx, logger, tracingConf)
+	if err != nil {
+		t.Fatalf("SetupTracingFromParsedConfig failed with empty config: %v", err)
+	}
+}

--- a/internal/tracing/tracer.go
+++ b/internal/tracing/tracer.go
@@ -6,14 +6,17 @@ package tracing
 
 import (
 	"context"
-	"sync"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
 )
 
+// Tracer returns a tracer from the global OTel TracerProvider. The result is
+// intentionally not cached because the global provider is set after init-time
+// (in SetupTracingFromParsedConfig), so caching would risk capturing the noop
+// provider if Tracer() were called before tracing is configured.
 func Tracer() trace.Tracer {
-	return sync.OnceValue(func() trace.Tracer { return otel.GetTracerProvider().Tracer("parquet-gateway") })()
+	return otel.GetTracerProvider().Tracer("parquet-gateway")
 }
 
 func SpanFromContext(ctx context.Context) trace.Span {

--- a/internal/util/promql.go
+++ b/internal/util/promql.go
@@ -9,21 +9,27 @@ import (
 	"github.com/prometheus/prometheus/promql/parser"
 )
 
-// ComputeResultMetrics returns series and sample counts for a PromQL query result.
-func ComputeResultMetrics(value parser.Value) (seriesCount, sampleCount int64) {
+// ComputeResultMetrics returns series, float sample, and histogram sample counts for a PromQL query result.
+func ComputeResultMetrics(value parser.Value) (seriesCount, floatSampleCount, histogramSampleCount int64) {
 	switch results := value.(type) {
 	case promql.Vector:
 		seriesCount = int64(len(results))
-		sampleCount = int64(len(results))
+		for _, s := range results {
+			if s.H != nil {
+				histogramSampleCount++
+			} else {
+				floatSampleCount++
+			}
+		}
 	case promql.Matrix:
 		seriesCount = int64(len(results))
 		for _, series := range results {
-			sampleCount += int64(len(series.Floats))
-			sampleCount += int64(len(series.Histograms))
+			floatSampleCount += int64(len(series.Floats))
+			histogramSampleCount += int64(len(series.Histograms))
 		}
 	case promql.Scalar:
 		seriesCount = 1
-		sampleCount = 1
+		floatSampleCount = 1
 	}
 	return
 }

--- a/internal/util/promql.go
+++ b/internal/util/promql.go
@@ -1,0 +1,29 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package util
+
+import (
+	"github.com/prometheus/prometheus/promql"
+	"github.com/prometheus/prometheus/promql/parser"
+)
+
+// ComputeResultMetrics returns series and sample counts for a PromQL query result.
+func ComputeResultMetrics(value parser.Value) (seriesCount, sampleCount int64) {
+	switch results := value.(type) {
+	case promql.Vector:
+		seriesCount = int64(len(results))
+		sampleCount = int64(len(results))
+	case promql.Matrix:
+		seriesCount = int64(len(results))
+		for _, series := range results {
+			sampleCount += int64(len(series.Floats))
+			sampleCount += int64(len(series.Histograms))
+		}
+	case promql.Scalar:
+		seriesCount = 1
+		sampleCount = 1
+	}
+	return
+}

--- a/internal/util/promql.go
+++ b/internal/util/promql.go
@@ -7,10 +7,16 @@ package util
 import (
 	"github.com/prometheus/prometheus/promql"
 	"github.com/prometheus/prometheus/promql/parser"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
-// ComputeResultMetrics returns series, float sample, and histogram sample counts for a PromQL query result.
-func ComputeResultMetrics(value parser.Value) (seriesCount, floatSampleCount, histogramSampleCount int64) {
+// InjectResultMetrics adds series and sample count attributes to span for a PromQL query result.
+func InjectResultMetrics(span trace.Span, value parser.Value) {
+	if !span.IsRecording() {
+		return
+	}
+	var seriesCount, floatSampleCount, histogramSampleCount int64
 	switch results := value.(type) {
 	case promql.Vector:
 		seriesCount = int64(len(results))
@@ -31,5 +37,10 @@ func ComputeResultMetrics(value parser.Value) (seriesCount, floatSampleCount, hi
 		seriesCount = 1
 		floatSampleCount = 1
 	}
-	return
+	span.SetAttributes(
+		attribute.Int64("result.series", seriesCount),
+		attribute.Int64("result.total_samples", floatSampleCount+histogramSampleCount),
+		attribute.Int64("result.float_samples", floatSampleCount),
+		attribute.Int64("result.histogram_samples", histogramSampleCount),
+	)
 }


### PR DESCRIPTION
This PR makes a number of tracing-related changes.

I used a LLM tool to assist with the development and testing of this change series, but only step by step and with plenty of manual review and editing. I haven't scrutinised the test cover as closely as the rest.

## Switch to config-file based trace configuration

* Switch tracing configuration loading to use the [Thanos tracing configuration file format](https://thanos.io/tip/thanos/tracing.md/) to configure OpenTelemetry tracing, using Thanos's own initialization and loading code. Like Thanos, an inline-file-as-commandline-arg approach is also supported.
* Adapt existing commandline flag processing for trace configuration by generating a Thanos trace configuration internally and passing that to the Thanos trace initialisation code.
* Because Thanos does not support the stdout (console) trace exporter, mark it deprecated and warn when it is used.

## Fix incorrect tracer memoization

The tracer was being memoized when initialised, but this could lead to a race with trace initialisation that caused the noop tracer to be cached. Remove the unnecessary memoization.

## Additional trace span attributes

* Add new `query.expr` trace span attribute to thanos.Query/QueryRange gRPC trace event, to record the query-text in the incoming query.
* Add `result.series` and `result.samples` counts to the trace events for Query gRPC responses.
* Add `result.series` and `result.samples` span attributes to Series gRPC response trace events.
* Add a `series.matchers` attribute to trace spans for Series gRPC requests.
* Wrap promql engine execution in a trace span to make it easier to identify time spent in execution vs setup, result-sending, etc.