### PR TITLE
locate/convert: add retention functionality

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -212,6 +212,49 @@ type discoveryOpts struct {
 	discoveryConcurrency int
 }
 
+func setupDeleter(ctx context.Context, g *run.Group, log *slog.Logger, bkt objstore.Bucket, discoverer *locate.Discoverer, retentionPeriod time.Duration, interval time.Duration) error {
+	if retentionPeriod == 0 {
+		return nil
+	}
+	deleteMarker := locate.NewRetentionDurationMarker(discoverer, bkt, retentionPeriod, log)
+	deleter := locate.NewRetentionDurationDeleter(bkt)
+
+	ctx, cancel := context.WithCancel(ctx)
+	g.Add(func() error {
+		return runutil.Repeat(interval, ctx.Done(), func() error {
+			log.Debug("Running deleter")
+
+			iterCtx, iterCancel := context.WithTimeout(ctx, interval)
+			defer iterCancel()
+			if err := deleter.DeleteMarkedStreams(iterCtx); err != nil {
+				log.Warn("Unable to delete marked streams", slog.Any("err", err))
+			}
+			return nil
+		})
+	}, func(error) {
+		log.Info("Stopping deleter")
+		cancel()
+	})
+
+	g.Add(func() error {
+		return runutil.Repeat(interval, ctx.Done(), func() error {
+			log.Debug("Running deletion marking")
+
+			iterCtx, iterCancel := context.WithTimeout(ctx, interval)
+			defer iterCancel()
+			if err := deleteMarker.MarkExpiredStreams(iterCtx); err != nil {
+				log.Warn("Unable to mark expired streams", slog.Any("err", err))
+			}
+			return nil
+		})
+	}, func(error) {
+		log.Info("Stopping deletion marking")
+		cancel()
+	})
+
+	return nil
+}
+
 func setupDiscovery(ctx context.Context, g *run.Group, log *slog.Logger, bkt objstore.Bucket, opts discoveryOpts) (*locate.Discoverer, error) {
 	discoverer := locate.NewDiscoverer(bkt, locate.MetaConcurrency(opts.discoveryConcurrency), locate.Logger(log))
 

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -41,6 +41,11 @@ type convertOpts struct {
 	tsdbDiscover    tsdbDiscoveryOpts
 	conversion      conversionOpts
 	internalAPI     apiOpts
+	retentionOpts   retentionOpts
+}
+
+type retentionOpts struct {
+	retentionPeriodDays uint64
 }
 
 type conversionOpts struct {
@@ -70,6 +75,11 @@ func (opts *convertOpts) registerFlags(cmd *kingpin.CmdClause) {
 	opts.parquetDiscover.registerConvertParquetFlags(cmd)
 	opts.tsdbDiscover.registerConvertTSDBFlags(cmd)
 	opts.internalAPI.registerConvertFlags(cmd)
+	opts.retentionOpts.registerFlags(cmd)
+}
+
+func (opts *retentionOpts) registerFlags(cmd *kingpin.CmdClause) {
+	cmd.Flag("convert.retention-days", "number of days after which the converted parquet files will be marked for deletion. Zero disables this functionality.").Default("0").Uint64Var(&opts.retentionPeriodDays)
 }
 
 func (opts *conversionOpts) registerFlags(cmd *kingpin.CmdClause) {
@@ -148,6 +158,16 @@ func registerConvertApp(app *kingpin.Application) (*kingpin.CmdClause, func(cont
 			return fmt.Errorf("unable to setup parquet discovery: %s", err)
 		}
 
+		const maxRetentionDays = 36500 // Otherwise the multiplication overflows.
+
+		if opts.retentionOpts.retentionPeriodDays > maxRetentionDays {
+			return fmt.Errorf("--convert.retention-days must not exceed %d", maxRetentionDays)
+		}
+
+		if err := setupDeleter(ctx, &g, log, parquetBkt, parquetDiscoverer, time.Duration(opts.retentionOpts.retentionPeriodDays)*24*time.Hour, opts.parquetDiscover.discoveryInterval); err != nil {
+			return fmt.Errorf("unable to setup deleter: %s", err)
+		}
+
 		planner := convert.NewPlanner(time.Now().Add(-opts.conversion.gracePeriod), opts.conversion.maxDays)
 		blkDir := filepath.Join(opts.conversion.tempDir, ".blocks")
 		bufferDir := filepath.Join(opts.conversion.tempDir, ".buffers")
@@ -169,7 +189,7 @@ func registerConvertApp(app *kingpin.Application) (*kingpin.CmdClause, func(cont
 				Help: "How many TODO steps were reported by the planner the last time",
 			})
 			return runutil.Repeat(opts.conversion.progressInterval, ctx.Done(), func() error {
-				plan := planner.Plan(tsdbDiscoverer.Streams(), parquetDiscoverer.Streams())
+				plan := planner.Plan(tsdbDiscoverer.Streams(), parquetDiscoverer.Streams().Streams)
 				todoConvert.Set(float64(len(plan.Steps)))
 				return nil
 			})
@@ -230,11 +250,11 @@ func advanceConversion(
 	tsdbMetas := tsdbDiscoverer.Streams()
 
 	streamHashMap := make(map[schema.ExternalLabelsHash]schema.ExternalLabels)
-	for _, discoveredStream := range parquetStreams {
+	for _, discoveredStream := range parquetStreams.Streams {
 		streamHashMap[discoveredStream.ExternalLabels.Hash()] = discoveredStream.ExternalLabels
 	}
 
-	plan := planner.Plan(tsdbMetas, parquetStreams)
+	plan := planner.Plan(tsdbMetas, parquetStreams.Streams)
 	if len(plan.Steps) == 0 {
 		log.Info("Nothing to do")
 		return nil

--- a/convert/convert_test.go
+++ b/convert/convert_test.go
@@ -204,10 +204,10 @@ func TestConverter(t *testing.T) {
 	}
 	streams := discoverer.Streams()
 
-	if n := len(streams); n != 1 {
+	if n := len(streams.Streams); n != 1 {
 		t.Fatalf("unexpected number of metas: %d", n)
 	}
-	meta := streams[slices.Collect(maps.Keys(streams))[0]].Metas[0]
+	meta := streams.Streams[slices.Collect(maps.Keys(streams.Streams))[0]].Metas[0]
 
 	if n := meta.Shards; n != 2 {
 		t.Fatalf("unexpected number of shards: %d", n)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thanos-io/thanos-parquet-gateway
 
-go 1.24.2
+go 1.25.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6

--- a/locate/deletion.go
+++ b/locate/deletion.go
@@ -1,0 +1,169 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package locate
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"path"
+	"slices"
+	"time"
+
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos-parquet-gateway/proto/metapb"
+	"github.com/thanos-io/thanos-parquet-gateway/schema"
+	"google.golang.org/protobuf/proto"
+)
+
+const DeletionMarkerName = "deletion-marker.pb"
+
+type DeletionMarkerFilter struct{}
+
+func (d *DeletionMarkerFilter) ShouldUnload(dateFiles []string) bool {
+	return slices.Contains(dateFiles, DeletionMarkerName)
+}
+
+const RetentionDurationMessage = "Retention duration expired"
+
+const deleteConsistencyDelay = 12 * time.Hour
+
+func NewRetentionDurationDeleter(bkt objstore.Bucket) *RetentionDurationDeleter {
+	return &RetentionDurationDeleter{
+		bkt: bkt,
+	}
+}
+
+func (d *RetentionDurationDeleter) DeleteMarkedStreams(ctx context.Context) error {
+	deletePaths := []string{}
+
+	if err := d.bkt.IterWithAttributes(ctx, "", func(attrs objstore.IterObjectAttributes) error {
+		date, fn, eh, ok := schema.SplitBlockPath(attrs.Name)
+		if !ok {
+			return nil
+		}
+		if fn != DeletionMarkerName {
+			return nil
+		}
+
+		lm, ok := attrs.LastModified()
+		if !ok {
+			return fmt.Errorf("object %s does not have a last modified time", attrs.Name)
+		}
+
+		if time.Since(lm) < deleteConsistencyDelay {
+			return nil
+		}
+
+		deletePaths = append(deletePaths, path.Join(eh.String(), date.String()))
+
+		return nil
+	}, objstore.WithRecursiveIter(), objstore.WithUpdatedAt()); err != nil {
+		return fmt.Errorf("iterating objects: %w", err)
+	}
+
+	for _, dp := range deletePaths {
+		if err := d.bkt.Delete(ctx, path.Join(dp, schema.MetaFile)); err != nil && !d.bkt.IsObjNotFoundErr(err) {
+			return fmt.Errorf("deleting meta.pb: %w", err)
+		}
+
+		for i := 0; ; i++ {
+			var notFoundErrs = 0
+
+			if err := d.bkt.Delete(ctx, path.Join(dp, fmt.Sprintf("%d.%s", i, "labels.parquet"))); err != nil {
+				if d.bkt.IsObjNotFoundErr(err) {
+					notFoundErrs++
+				} else {
+					return fmt.Errorf("deleting shard: %w", err)
+				}
+			}
+
+			if err := d.bkt.Delete(ctx, path.Join(dp, fmt.Sprintf("%d.%s", i, "chunks.parquet"))); err != nil {
+				if d.bkt.IsObjNotFoundErr(err) {
+					notFoundErrs++
+				} else {
+					return fmt.Errorf("deleting shard: %w", err)
+				}
+			}
+
+			if notFoundErrs == 2 {
+				break
+			}
+		}
+
+		if err := d.bkt.Delete(ctx, path.Join(dp, DeletionMarkerName)); err != nil {
+			return fmt.Errorf("deleting deletion marker: %w", err)
+		}
+	}
+
+	return nil
+}
+
+type RetentionDurationDeleter struct {
+	bkt objstore.Bucket
+}
+
+func NewRetentionDurationMarker(d Discoverable, bkt objstore.Bucket, retentionDuration time.Duration, l *slog.Logger) *RetentionDurationMarker {
+	return &RetentionDurationMarker{
+		d:                 d,
+		bkt:               bkt,
+		retentionDuration: retentionDuration,
+		l:                 l,
+	}
+}
+
+type RetentionDurationMarker struct {
+	d   Discoverable
+	bkt objstore.Bucket
+
+	retentionDuration time.Duration
+	lastSeenSyncTime  time.Time
+
+	l *slog.Logger
+}
+
+type Discoverable interface {
+	Streams() DiscovererStreams
+}
+
+func (d *RetentionDurationMarker) MarkExpiredStreams(ctx context.Context) error {
+	if d.retentionDuration == 0 {
+		return nil
+	}
+	st := d.d.Streams()
+
+	if st.LastSync.Equal(d.lastSeenSyncTime) || st.LastSync.Before(d.lastSeenSyncTime) {
+		return nil
+	}
+
+	cutOffDate := time.Now().UTC().Add(-d.retentionDuration)
+
+	for streamHash, stream := range st.Streams {
+		for day := range stream.DiscoveredDays {
+			if day.ToTime().After(cutOffDate) || day.ToTime().Equal(cutOffDate) {
+				continue
+			}
+			d.l.Info("Marking stream as expired", "stream_hash", streamHash, "date", day.String(), "retention_duration", d.retentionDuration.String())
+
+			dm := &metapb.DeletionMark{
+				Reason: RetentionDurationMessage,
+			}
+
+			md, err := proto.Marshal(dm)
+			if err != nil {
+				return fmt.Errorf("marshaling deletion marker: %w", err)
+			}
+
+			if err := d.bkt.Upload(ctx, path.Join(streamHash.String(), day.String(), DeletionMarkerName), bytes.NewReader(md)); err != nil {
+				return fmt.Errorf("uploading deletion marker: %w", err)
+			}
+		}
+	}
+
+	d.lastSeenSyncTime = st.LastSync
+
+	return nil
+}

--- a/locate/deletion_test.go
+++ b/locate/deletion_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache 2.0 license found in the LICENSE file or at:
+//     https://opensource.org/licenses/Apache-2.0
+
+package locate
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"path"
+	"slices"
+	"testing"
+	"time"
+
+	"testing/synctest"
+
+	"github.com/stretchr/testify/require"
+	"github.com/thanos-io/objstore"
+	"github.com/thanos-io/thanos-parquet-gateway/internal/util"
+	"github.com/thanos-io/thanos-parquet-gateway/schema"
+)
+
+type mockDiscoverable struct {
+	st DiscovererStreams
+}
+
+func (m *mockDiscoverable) Streams() DiscovererStreams {
+	return m.st
+}
+
+func TestDeleter(t *testing.T) {
+	b := objstore.NewInMemBucket()
+	md := &mockDiscoverable{}
+
+	f := &RetentionDurationMarker{
+		d:                 md,
+		l:                 slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{})),
+		bkt:               b,
+		retentionDuration: 24 * time.Hour,
+	}
+
+	synctest.Test(t, func(t *testing.T) {
+		md.st = DiscovererStreams{
+			LastSync: time.Now(),
+			Streams: map[schema.ExternalLabelsHash]schema.ParquetBlocksStream{
+				schema.ExternalLabelsHash(1): {
+					DiscoveredDays: map[util.Date]struct{}{
+						util.NewDate(1995, 1, 1):   {},
+						util.NewDate(2000, 1, 1):   {},
+						util.NewDate(1999, 12, 31): {},
+						util.NewDate(1999, 12, 30): {},
+					},
+				},
+			},
+		}
+
+		require.NoError(t, f.MarkExpiredStreams(t.Context()))
+
+		objs := []string{}
+		require.NoError(t, b.Iter(t.Context(), "", func(s string) error {
+			t.Log("Found file in bucket:", s)
+			objs = append(objs, s)
+			return nil
+		}, objstore.WithRecursiveIter()))
+
+		require.Equal(t, true, slices.Contains(objs, `1/1995-01-01/`+DeletionMarkerName))
+		require.Equal(t, false, slices.Contains(objs, `1/1999-12-31/`+DeletionMarkerName))
+		require.Equal(t, true, slices.Contains(objs, `1/1999-12-30/`+DeletionMarkerName))
+		require.Equal(t, false, slices.Contains(objs, `1/2000-01-01/`+DeletionMarkerName))
+
+	})
+
+}
+
+func createEmptyBlock(t *testing.T, b *objstore.InMemBucket, h schema.ExternalLabelsHash, d util.Date, shards int) {
+	t.Helper()
+
+	ctx := t.Context()
+	for i := range shards {
+		require.NoError(t, b.Upload(ctx, schema.LabelsPfileNameForShard(h, d, i), bytes.NewReader(nil)))
+		require.NoError(t, b.Upload(ctx, schema.ChunksPfileNameForShard(h, d, i), bytes.NewReader(nil)))
+	}
+	require.NoError(t, b.Upload(ctx, schema.MetaFileNameForBlock(d, h), bytes.NewReader(nil)))
+	require.NoError(t, b.Upload(ctx, path.Join(h.String(), d.String()), bytes.NewReader(nil)))
+}
+
+func TestRetentionDurationDeleter(t *testing.T) {
+	const (
+		hash1 schema.ExternalLabelsHash = 111
+		hash2 schema.ExternalLabelsHash = 222
+	)
+
+	date1 := util.NewDate(2020, time.January, 1)
+	date2 := util.NewDate(2020, time.February, 1)
+
+	markerPath := func(h schema.ExternalLabelsHash, d util.Date) string {
+		return path.Join(h.String(), d.String(), DeletionMarkerName)
+	}
+
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T, b *objstore.InMemBucket)
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name: "no deletion markers - nothing deleted",
+			setup: func(t *testing.T, b *objstore.InMemBucket) {
+				createEmptyBlock(t, b, hash1, date1, 1)
+			},
+			wantPresent: []string{
+				schema.LabelsPfileNameForShard(hash1, date1, 0),
+				schema.ChunksPfileNameForShard(hash1, date1, 0),
+				schema.MetaFileNameForBlock(date1, hash1),
+			},
+		},
+		{
+			name: "marker within consistency delay - files not deleted",
+			setup: func(t *testing.T, b *objstore.InMemBucket) {
+				createEmptyBlock(t, b, hash1, date1, 1)
+				require.NoError(t, b.Upload(t.Context(), markerPath(hash1, date1), bytes.NewReader(nil)))
+			},
+			wantPresent: []string{
+				schema.LabelsPfileNameForShard(hash1, date1, 0),
+				schema.ChunksPfileNameForShard(hash1, date1, 0),
+				schema.MetaFileNameForBlock(date1, hash1),
+				markerPath(hash1, date1),
+			},
+		},
+		{
+			name: "marker beyond consistency delay - all files deleted",
+			setup: func(t *testing.T, b *objstore.InMemBucket) {
+				createEmptyBlock(t, b, hash1, date1, 1)
+				mp := markerPath(hash1, date1)
+				require.NoError(t, b.Upload(t.Context(), mp, bytes.NewReader(nil)))
+				require.NoError(t, b.ChangeLastModified(mp, time.Now().Add(-(deleteConsistencyDelay+time.Hour))))
+			},
+			wantAbsent: []string{
+				schema.LabelsPfileNameForShard(hash1, date1, 0),
+				schema.ChunksPfileNameForShard(hash1, date1, 0),
+				schema.MetaFileNameForBlock(date1, hash1),
+			},
+		},
+		{
+			name: "multiple streams - only expired one deleted",
+			setup: func(t *testing.T, b *objstore.InMemBucket) {
+				createEmptyBlock(t, b, hash1, date1, 1)
+				mp1 := markerPath(hash1, date1)
+				require.NoError(t, b.Upload(t.Context(), mp1, bytes.NewReader(nil)))
+				require.NoError(t, b.ChangeLastModified(mp1, time.Now().Add(-(deleteConsistencyDelay+time.Hour))))
+				createEmptyBlock(t, b, hash2, date2, 1)
+			},
+			wantAbsent: []string{
+				schema.LabelsPfileNameForShard(hash1, date1, 0),
+				schema.ChunksPfileNameForShard(hash1, date1, 0),
+				schema.MetaFileNameForBlock(date1, hash1),
+			},
+			wantPresent: []string{
+				schema.LabelsPfileNameForShard(hash2, date2, 0),
+				schema.ChunksPfileNameForShard(hash2, date2, 0),
+				schema.MetaFileNameForBlock(date2, hash2),
+			},
+		},
+		{
+			name: "multiple shards - all shards deleted",
+			setup: func(t *testing.T, b *objstore.InMemBucket) {
+				createEmptyBlock(t, b, hash1, date1, 3)
+				mp := markerPath(hash1, date1)
+				require.NoError(t, b.Upload(t.Context(), mp, bytes.NewReader(nil)))
+				require.NoError(t, b.ChangeLastModified(mp, time.Now().Add(-(deleteConsistencyDelay+time.Hour))))
+			},
+			wantAbsent: []string{
+				schema.LabelsPfileNameForShard(hash1, date1, 0),
+				schema.ChunksPfileNameForShard(hash1, date1, 0),
+				schema.LabelsPfileNameForShard(hash1, date1, 1),
+				schema.ChunksPfileNameForShard(hash1, date1, 1),
+				schema.LabelsPfileNameForShard(hash1, date1, 2),
+				schema.ChunksPfileNameForShard(hash1, date1, 2),
+				schema.MetaFileNameForBlock(date1, hash1),
+			},
+		},
+		{
+			name: "expired marker on one date, recent marker on another - only expired deleted",
+			setup: func(t *testing.T, b *objstore.InMemBucket) {
+				createEmptyBlock(t, b, hash1, date1, 1)
+				mp1 := markerPath(hash1, date1)
+				require.NoError(t, b.Upload(t.Context(), mp1, bytes.NewReader(nil)))
+				require.NoError(t, b.ChangeLastModified(mp1, time.Now().Add(-(deleteConsistencyDelay+time.Hour))))
+				createEmptyBlock(t, b, hash1, date2, 1)
+				require.NoError(t, b.Upload(t.Context(), markerPath(hash1, date2), bytes.NewReader(nil)))
+			},
+			wantAbsent: []string{
+				schema.LabelsPfileNameForShard(hash1, date1, 0),
+				schema.ChunksPfileNameForShard(hash1, date1, 0),
+				schema.MetaFileNameForBlock(date1, hash1),
+			},
+			wantPresent: []string{
+				schema.LabelsPfileNameForShard(hash1, date2, 0),
+				schema.ChunksPfileNameForShard(hash1, date2, 0),
+				schema.MetaFileNameForBlock(date2, hash1),
+				markerPath(hash1, date2),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := objstore.NewInMemBucket()
+			tc.setup(t, b)
+
+			d := NewRetentionDurationDeleter(b)
+			require.NoError(t, d.DeleteMarkedStreams(t.Context()))
+
+			for _, p := range tc.wantPresent {
+				ok, err := b.Exists(t.Context(), p)
+				require.NoError(t, err)
+				require.True(t, ok, "expected %q to be present", p)
+			}
+			for _, p := range tc.wantAbsent {
+				ok, err := b.Exists(t.Context(), p)
+				require.NoError(t, err)
+				require.False(t, ok, "expected %q to be absent", p)
+			}
+		})
+	}
+}

--- a/locate/discover.go
+++ b/locate/discover.go
@@ -54,6 +54,10 @@ func Logger(l *slog.Logger) DiscoveryOption {
 	}
 }
 
+type DiscovererFilter interface {
+	ShouldUnload([]string) bool
+}
+
 type Discoverer struct {
 	bkt objstore.Bucket
 
@@ -63,6 +67,16 @@ type Discoverer struct {
 	concurrency int
 
 	l *slog.Logger
+
+	filters []DiscovererFilter
+
+	lastSync time.Time
+}
+
+type NoMetaFilter struct{}
+
+func (n *NoMetaFilter) ShouldUnload(dateFiles []string) bool {
+	return !slices.Contains(dateFiles, schema.MetaFile)
 }
 
 func NewDiscoverer(bkt objstore.Bucket, opts ...DiscoveryOption) *Discoverer {
@@ -78,12 +92,23 @@ func NewDiscoverer(bkt objstore.Bucket, opts ...DiscoveryOption) *Discoverer {
 		blocks:      make(map[schema.ExternalLabelsHash]schema.ParquetBlocksStream),
 		concurrency: cfg.concurrency,
 		l:           cfg.l,
+		filters: []DiscovererFilter{
+			&DeletionMarkerFilter{},
+			&NoMetaFilter{},
+		},
 	}
 }
 
-func (s *Discoverer) Streams() map[schema.ExternalLabelsHash]schema.ParquetBlocksStream {
+type DiscovererStreams struct {
+	Streams  map[schema.ExternalLabelsHash]schema.ParquetBlocksStream
+	LastSync time.Time
+}
+
+func (s *Discoverer) Streams() DiscovererStreams {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	r := DiscovererStreams{}
 
 	res := make(map[schema.ExternalLabelsHash]schema.ParquetBlocksStream, len(s.blocks))
 
@@ -91,7 +116,10 @@ func (s *Discoverer) Streams() map[schema.ExternalLabelsHash]schema.ParquetBlock
 		res[k] = s.blocks[k]
 	}
 
-	return res
+	r.Streams = res
+	r.LastSync = s.lastSync
+
+	return r
 }
 
 func (s *Discoverer) Discover(ctx context.Context) error {
@@ -109,7 +137,12 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 		if eh, ok := schema.SplitStreamPath(n); ok {
 			fbs, ok := futureBlocks[eh]
 			if !ok {
-				fbs = futureBlocksStream{}
+				fbs = futureBlocksStream{
+					ParquetBlocksStream: schema.ParquetBlocksStream{
+						DiscoveredDays: make(map[util.Date]struct{}),
+					},
+					filesByDate: make(map[util.Date][]string),
+				}
 			}
 
 			if fbs.streamFile != "" {
@@ -124,19 +157,12 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 		if date, file, eh, ok := schema.SplitBlockPath(n); ok {
 			fbs, ok := futureBlocks[eh]
 			if !ok {
-				fbs = futureBlocksStream{}
-			}
-
-			if fbs.DiscoveredDays == nil {
-				fbs.DiscoveredDays = make(map[util.Date]struct{})
-			}
-
-			if file == schema.MetaFile {
-				fbs.DiscoveredDays[date] = struct{}{}
-			}
-
-			if fbs.filesByDate == nil {
-				fbs.filesByDate = make(map[util.Date][]string)
+				fbs = futureBlocksStream{
+					ParquetBlocksStream: schema.ParquetBlocksStream{
+						DiscoveredDays: make(map[util.Date]struct{}),
+					},
+					filesByDate: make(map[util.Date][]string),
+				}
 			}
 
 			fbs.filesByDate[date] = append(fbs.filesByDate[date], file)
@@ -198,12 +224,25 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 
 	for discoveredHash := range futureBlocks {
 		for blockDate, dateFiles := range futureBlocks[discoveredHash].filesByDate {
-			if !slices.Contains(dateFiles, schema.MetaFile) {
+			for _, f := range s.filters {
+				if !f.ShouldUnload(dateFiles) {
+					continue
+				}
+
 				delete(futureBlocks[discoveredHash].filesByDate, blockDate)
-			} else {
-				futureBlocks[discoveredHash].DiscoveredDays[blockDate] = struct{}{}
+				break
 			}
 		}
+	}
+
+	for discoveredHash, fb := range futureBlocks {
+		for blockDate, fn := range fb.filesByDate {
+			if !slices.Contains(fn, schema.MetaFile) {
+				continue
+			}
+			fb.DiscoveredDays[blockDate] = struct{}{}
+		}
+		futureBlocks[discoveredHash] = fb
 	}
 
 	downloadedMetas := make(map[schema.ExternalLabelsHash][]schema.Meta, len(futureBlocks))
@@ -260,6 +299,7 @@ func (s *Discoverer) Discover(ctx context.Context) error {
 		syncMaxTime.WithLabelValues(whatDiscoverer).Set(float64(maxt))
 	}
 	syncLastSuccessfulTime.WithLabelValues(whatDiscoverer).SetToCurrentTime()
+	s.lastSync = time.Now()
 
 	return nil
 }
@@ -525,9 +565,7 @@ func (s *TSDBDiscoverer) Discover(ctx context.Context) error {
 		defer wg.Wait()
 
 		for range s.concurrency {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for k := range workerC {
 					meta, err := s.readMetaFile(ctx, k)
 					if err != nil {
@@ -536,7 +574,7 @@ func (s *TSDBDiscoverer) Discover(ctx context.Context) error {
 						metaC <- metaOrError{m: meta}
 					}
 				}
-			}()
+			})
 		}
 	}()
 

--- a/locate/discover_test.go
+++ b/locate/discover_test.go
@@ -52,9 +52,9 @@ func TestDiscoverer(t *testing.T) {
 		require.NoError(t, discoverer.Discover(ctx))
 
 		metas := discoverer.Streams()
-		require.Len(t, metas, 1)
+		require.Len(t, metas.Streams, 1)
 
-		stream := metas[extLabels.Hash()]
+		stream := metas.Streams[extLabels.Hash()]
 
 		if expect, got := []util.Date{util.NewDate(1970, time.January, 1)}, slices.SortedFunc(maps.Keys(stream.DiscoveredDays), func(a, b util.Date) int { return int(a.ToTime().Sub(b.ToTime())) }); !slices.Equal(got, expect) {
 			t.Errorf("expected: %+v, got: %+v", expect, got)
@@ -68,9 +68,9 @@ func TestDiscoverer(t *testing.T) {
 		}
 
 		streams := discoverer.Streams()
-		require.Len(t, streams, 1)
+		require.Len(t, streams.Streams, 1)
 
-		stream = streams[extLabels.Hash()]
+		stream = streams.Streams[extLabels.Hash()]
 		if expect, got := []util.Date{util.NewDate(1970, time.January, 1), util.NewDate(1970, time.January, 2)}, slices.SortedFunc(maps.Keys(stream.DiscoveredDays), func(a, b util.Date) int { return int(a.ToTime().Sub(b.ToTime())) }); !slices.Equal(got, expect) {
 			t.Errorf("expected: %+v, got: %+v", expect, got)
 		}
@@ -78,14 +78,39 @@ func TestDiscoverer(t *testing.T) {
 		require.Equal(t, extLabels, stream.ExternalLabels)
 	})
 
+	t.Run("does not detect blocks that have a deletion marker", func(t *testing.T) {
+		require.NoError(t, bkt.Upload(t.Context(), path.Join(extLabels.Hash().String(), "1970-01-01", DeletionMarkerName), bytes.NewReader([]byte("foo"))))
+		require.NoError(t, discoverer.Discover(ctx))
+
+		metas := discoverer.Streams()
+		require.Len(t, metas.Streams, 1)
+
+		stream := metas.Streams[extLabels.Hash()]
+
+		if expect, got := []util.Date{util.NewDate(1970, time.January, 2)}, slices.SortedFunc(maps.Keys(stream.DiscoveredDays), func(a, b util.Date) int { return int(a.ToTime().Sub(b.ToTime())) }); !slices.Equal(got, expect) {
+			t.Errorf("expected: %+v, got: %+v", expect, got)
+		}
+
+		require.NoError(t, bkt.Delete(t.Context(), path.Join(extLabels.Hash().String(), "1970-01-01", DeletionMarkerName)))
+		require.NoError(t, discoverer.Discover(ctx))
+
+		metas = discoverer.Streams()
+		require.Len(t, metas.Streams, 1)
+		stream = metas.Streams[extLabels.Hash()]
+
+		if expect, got := []util.Date{util.NewDate(1970, time.January, 1), util.NewDate(1970, time.January, 2)}, slices.SortedFunc(maps.Keys(stream.DiscoveredDays), func(a, b util.Date) int { return int(a.ToTime().Sub(b.ToTime())) }); !slices.Equal(got, expect) {
+			t.Errorf("expected: %+v, got: %+v", expect, got)
+		}
+	})
+
 	t.Run("does not detect blocks with no meta.pb", func(t *testing.T) {
 		require.NoError(t, bkt.Delete(ctx, path.Join(extLabels.Hash().String(), "1970-01-01", "meta.pb")))
 		require.NoError(t, discoverer.Discover(ctx))
 
 		metas := discoverer.Streams()
-		require.Len(t, metas, 1)
+		require.Len(t, metas.Streams, 1)
 
-		stream := metas[extLabels.Hash()]
+		stream := metas.Streams[extLabels.Hash()]
 
 		if expect, got := []util.Date{util.NewDate(1970, time.January, 2)}, slices.SortedFunc(maps.Keys(stream.DiscoveredDays), func(a, b util.Date) int { return int(a.ToTime().Sub(b.ToTime())) }); !slices.Equal(got, expect) {
 			t.Errorf("expected: %+v, got: %+v", expect, got)
@@ -117,7 +142,7 @@ func TestDiscoverer(t *testing.T) {
 
 		streams := discoverer.Streams()
 
-		stream, ok := streams[0]
+		stream, ok := streams.Streams[0]
 		require.True(t, ok)
 
 		if expect, got := []util.Date{util.NewDate(1970, time.January, 2)}, slices.SortedFunc(maps.Keys(stream.DiscoveredDays), func(a, b util.Date) int { return int(a.ToTime().Sub(b.ToTime())) }); !slices.Equal(got, expect) {
@@ -136,14 +161,14 @@ func TestDiscoverer(t *testing.T) {
 
 		streams := discoverer.Streams()
 
-		require.Contains(t, streams, nonZeroLbls.Hash())
+		require.Contains(t, streams.Streams, nonZeroLbls.Hash())
 		require.NoError(t, bkt.Delete(ctx, path.Join(nonZeroLbls.Hash().String(), "stream.pb")))
 
 		require.NoError(t, discoverer.Discover(ctx))
 
 		streams = discoverer.Streams()
-		require.Len(t, streams, 1)
-		require.NotContains(t, streams, nonZeroLbls.Hash())
+		require.Len(t, streams.Streams, 1)
+		require.NotContains(t, streams.Streams, nonZeroLbls.Hash())
 	})
 }
 

--- a/locate/syncer.go
+++ b/locate/syncer.go
@@ -112,7 +112,7 @@ func (s *Syncer) Blocks() []*db.Block {
 	return s.filterBlocks(s.cached)
 }
 
-func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLabelsHash]schema.ParquetBlocksStream) error {
+func (s *Syncer) Sync(ctx context.Context, parquetStreams DiscovererStreams) error {
 	type blockOrError struct {
 		blk       *db.Block
 		extLabels schema.ExternalLabels
@@ -133,7 +133,7 @@ func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLab
 		go func() {
 			defer close(workerC)
 
-			for streamHash, stream := range parquetStreams {
+			for streamHash, stream := range parquetStreams.Streams {
 				if _, ok := s.blocks[streamHash]; !ok {
 					s.blocks[streamHash] = make(map[util.Date]*db.Block)
 				}
@@ -142,8 +142,9 @@ func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLab
 						continue
 					}
 					workerC <- metaHashTuple{
-						m:         m,
-						extLabels: stream.ExternalLabels,
+						m:          m,
+						extLabels:  stream.ExternalLabels,
+						streamHash: streamHash,
 					}
 				}
 			}
@@ -153,9 +154,7 @@ func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLab
 		defer wg.Wait()
 
 		for range s.concurrency {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				for mh := range workerC {
 					blk, err := newBlockForMeta(ctx, s.bkt, mh.extLabels, mh.m, s.blockOpts...)
 					if err != nil {
@@ -164,7 +163,7 @@ func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLab
 						blkC <- blockOrError{blk: blk, extLabels: mh.extLabels}
 					}
 				}
-			}()
+			})
 		}
 	}()
 
@@ -184,7 +183,7 @@ func (s *Syncer) Sync(ctx context.Context, parquetStreams map[schema.ExternalLab
 
 	var numBlocks int
 	for stream := range s.blocks {
-		if _, ok := parquetStreams[stream]; !ok {
+		if _, ok := parquetStreams.Streams[stream]; !ok {
 			delete(s.blocks, stream)
 		}
 	}

--- a/locate/syncer_test.go
+++ b/locate/syncer_test.go
@@ -51,7 +51,9 @@ func TestSyncer(t *testing.T) {
 			},
 		}
 
-		if err := syncer.Sync(ctx, m); err != nil {
+		if err := syncer.Sync(ctx, DiscovererStreams{
+			Streams: m,
+		}); err != nil {
 			tt.Fatalf("unable to sync blocks: %s", err)
 		}
 
@@ -59,7 +61,9 @@ func TestSyncer(t *testing.T) {
 			tt.Errorf("expected: %+v, got: %+v", expect, got)
 		}
 
-		if err := syncer.Sync(ctx, map[schema.ExternalLabelsHash]schema.ParquetBlocksStream{}); err != nil {
+		if err := syncer.Sync(ctx, DiscovererStreams{
+			Streams: map[schema.ExternalLabelsHash]schema.ParquetBlocksStream{},
+		}); err != nil {
 			tt.Fatalf("unable to sync blocks: %s", err)
 		}
 

--- a/proto/metapb/meta.pb.go
+++ b/proto/metapb/meta.pb.go
@@ -149,6 +149,50 @@ func (x *Columns) GetColumns() []string {
 	return nil
 }
 
+type DeletionMark struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Reason        string                 `protobuf:"bytes,1,opt,name=reason,proto3" json:"reason,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeletionMark) Reset() {
+	*x = DeletionMark{}
+	mi := &file_meta_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeletionMark) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeletionMark) ProtoMessage() {}
+
+func (x *DeletionMark) ProtoReflect() protoreflect.Message {
+	mi := &file_meta_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeletionMark.ProtoReflect.Descriptor instead.
+func (*DeletionMark) Descriptor() ([]byte, []int) {
+	return file_meta_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *DeletionMark) GetReason() string {
+	if x != nil {
+		return x.Reason
+	}
+	return ""
+}
+
 var File_meta_proto protoreflect.FileDescriptor
 
 const file_meta_proto_rawDesc = "" +
@@ -166,7 +210,9 @@ const file_meta_proto_rawDesc = "" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12#\n" +
 	"\x05value\x18\x02 \x01(\v2\r.meta.ColumnsR\x05value:\x028\x01\"#\n" +
 	"\aColumns\x12\x18\n" +
-	"\acolumns\x18\x01 \x03(\tR\acolumnsB:Z8github.com/thanos-io/thanos-parquet-gateway/proto/metapbb\x06proto3"
+	"\acolumns\x18\x01 \x03(\tR\acolumns\"&\n" +
+	"\fDeletionMark\x12\x16\n" +
+	"\x06reason\x18\x01 \x01(\tR\x06reasonB:Z8github.com/thanos-io/thanos-parquet-gateway/proto/metapbb\x06proto3"
 
 var (
 	file_meta_proto_rawDescOnce sync.Once
@@ -180,14 +226,15 @@ func file_meta_proto_rawDescGZIP() []byte {
 	return file_meta_proto_rawDescData
 }
 
-var file_meta_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_meta_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_meta_proto_goTypes = []any{
-	(*Metadata)(nil), // 0: meta.Metadata
-	(*Columns)(nil),  // 1: meta.Columns
-	nil,              // 2: meta.Metadata.ColumnsForNameEntry
+	(*Metadata)(nil),     // 0: meta.Metadata
+	(*Columns)(nil),      // 1: meta.Columns
+	(*DeletionMark)(nil), // 2: meta.DeletionMark
+	nil,                  // 3: meta.Metadata.ColumnsForNameEntry
 }
 var file_meta_proto_depIdxs = []int32{
-	2, // 0: meta.Metadata.columnsForName:type_name -> meta.Metadata.ColumnsForNameEntry
+	3, // 0: meta.Metadata.columnsForName:type_name -> meta.Metadata.ColumnsForNameEntry
 	1, // 1: meta.Metadata.ColumnsForNameEntry.value:type_name -> meta.Columns
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
@@ -207,7 +254,7 @@ func file_meta_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_meta_proto_rawDesc), len(file_meta_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/metapb/meta.proto
+++ b/proto/metapb/meta.proto
@@ -16,3 +16,7 @@ message Metadata {
 message Columns {
   repeated string columns = 1;
 }
+
+message DeletionMark {
+  string reason = 1;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ pkgs.mkShell {
   name = "env";
   hardeningDisable = [ "fortify" ];
   buildInputs = with pkgs; [
-    go_1_24
+    go_1_25
     gotools
     delve
     revive


### PR DESCRIPTION
Add retention functionality in the converter that works +- like the one in Thanos Compactor BUT it doesn't try to verify that the JSON contents of the marker are "good" to save on requests. If the write succeeds of the JSON file then we assume that the contents are good.