### PR TITLE
Fix retention deletion on S3

### DIFF
--- a/locate/deletion.go
+++ b/locate/deletion.go
@@ -66,35 +66,26 @@ func (d *RetentionDurationDeleter) DeleteMarkedStreams(ctx context.Context) erro
 	}
 
 	for _, dp := range deletePaths {
-		if err := d.bkt.Delete(ctx, path.Join(dp, schema.MetaFile)); err != nil && !d.bkt.IsObjNotFoundErr(err) {
-			return fmt.Errorf("deleting meta.pb: %w", err)
+		markerPath := path.Join(dp, DeletionMarkerName)
+
+		deleteObjects := []string{}
+		if err := d.bkt.Iter(ctx, dp+"/", func(name string) error {
+			if name == markerPath {
+				return nil
+			}
+			deleteObjects = append(deleteObjects, name)
+			return nil
+		}, objstore.WithRecursiveIter()); err != nil {
+			return fmt.Errorf("iterating marked stream %s: %w", dp, err)
 		}
 
-		for i := 0; ; i++ {
-			var notFoundErrs = 0
-
-			if err := d.bkt.Delete(ctx, path.Join(dp, fmt.Sprintf("%d.%s", i, "labels.parquet"))); err != nil {
-				if d.bkt.IsObjNotFoundErr(err) {
-					notFoundErrs++
-				} else {
-					return fmt.Errorf("deleting shard: %w", err)
-				}
-			}
-
-			if err := d.bkt.Delete(ctx, path.Join(dp, fmt.Sprintf("%d.%s", i, "chunks.parquet"))); err != nil {
-				if d.bkt.IsObjNotFoundErr(err) {
-					notFoundErrs++
-				} else {
-					return fmt.Errorf("deleting shard: %w", err)
-				}
-			}
-
-			if notFoundErrs == 2 {
-				break
+		for _, name := range deleteObjects {
+			if err := d.bkt.Delete(ctx, name); err != nil && !d.bkt.IsObjNotFoundErr(err) {
+				return fmt.Errorf("deleting object %s: %w", name, err)
 			}
 		}
 
-		if err := d.bkt.Delete(ctx, path.Join(dp, DeletionMarkerName)); err != nil {
+		if err := d.bkt.Delete(ctx, markerPath); err != nil && !d.bkt.IsObjNotFoundErr(err) {
 			return fmt.Errorf("deleting deletion marker: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- delete marked parquet stream objects by listing the marked prefix instead of probing shard indexes indefinitely
- keep deletion-marker.pb until all other objects under the prefix are deleted
- tolerate already-deleted objects during retries

## Tests
- go test ./locate